### PR TITLE
Add tasks overview and user-task relation

### DIFF
--- a/demo/src/main/java/itis/semestrovka/demo/controller/AllTasksController.java
+++ b/demo/src/main/java/itis/semestrovka/demo/controller/AllTasksController.java
@@ -1,0 +1,28 @@
+package itis.semestrovka.demo.controller;
+
+import itis.semestrovka.demo.model.entity.Task;
+import itis.semestrovka.demo.service.TaskService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+import itis.semestrovka.demo.model.entity.User;
+import java.util.List;
+
+@Controller
+@RequestMapping("/tasks")
+@RequiredArgsConstructor
+public class AllTasksController {
+    private final TaskService taskService;
+
+    @GetMapping
+    public String list(Model model, @AuthenticationPrincipal User user) {
+        List<Task> tasks = taskService.findAll();
+        model.addAttribute("tasks", tasks);
+        model.addAttribute("title", "Все задачи");
+        return "task/all";
+    }
+}

--- a/demo/src/main/java/itis/semestrovka/demo/model/entity/Task.java
+++ b/demo/src/main/java/itis/semestrovka/demo/model/entity/Task.java
@@ -6,6 +6,8 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.HashSet;
+import java.util.Set;
 
 @Entity
 @Table(name = "tasks")
@@ -31,6 +33,15 @@ public class Task {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "assigned_user_id")
     private User assignedUser;
+
+    // Участники задачи (M2M)
+    @ManyToMany
+    @JoinTable(
+            name = "task_users",
+            joinColumns = @JoinColumn(name = "task_id"),
+            inverseJoinColumns = @JoinColumn(name = "user_id")
+    )
+    private Set<User> participants = new HashSet<>();
 
     // Заглушка для списка комментариев
     @OneToMany(mappedBy = "task", cascade = CascadeType.ALL)

--- a/demo/src/main/java/itis/semestrovka/demo/model/entity/User.java
+++ b/demo/src/main/java/itis/semestrovka/demo/model/entity/User.java
@@ -8,6 +8,8 @@ import org.springframework.security.core.userdetails.UserDetails;
 
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
 
 @Entity
 @Table(name = "users")
@@ -34,6 +36,10 @@ public class User implements UserDetails {
     @ManyToOne
     @JoinColumn(name = "team_id")
     private Team team;
+
+    // Задачи, в которых участвует пользователь
+    @ManyToMany(mappedBy = "participants")
+    private Set<Task> tasks = new HashSet<>();
 
     // --- UserDetails implementation ---
     @Override public Collection<Role> getAuthorities() { return Collections.singleton(role); }

--- a/demo/src/main/java/itis/semestrovka/demo/repository/TaskRepository.java
+++ b/demo/src/main/java/itis/semestrovka/demo/repository/TaskRepository.java
@@ -10,6 +10,8 @@ public interface TaskRepository extends JpaRepository<Task, Long> {
 
     List<Task> findAllByProjectId(Long projectId);
 
+    List<Task> findAllByParticipants_Id(Long userId);
+
     // для безопасного удаления через REST
     void deleteByIdAndProjectId(Long id, Long projectId);
 }

--- a/demo/src/main/java/itis/semestrovka/demo/service/TaskService.java
+++ b/demo/src/main/java/itis/semestrovka/demo/service/TaskService.java
@@ -14,6 +14,8 @@ public interface TaskService {
     void deleteById(Long id);            // удалить без проверки projectId
     Task findById(Long id);
     List<Task> findAllByProject(Long projectId);
+    List<Task> findAll();
+    List<Task> findAllByUser(Long userId);
 
     /*=== REST / AJAX ===*/
     Task create(Project project, TaskDto dto);     // POST JSON → Task

--- a/demo/src/main/java/itis/semestrovka/demo/service/impl/TaskServiceImpl.java
+++ b/demo/src/main/java/itis/semestrovka/demo/service/impl/TaskServiceImpl.java
@@ -41,6 +41,16 @@ public class TaskServiceImpl implements TaskService {
         return repo.findAllByProjectId(projectId);
     }
 
+    @Override
+    public List<Task> findAll() {
+        return repo.findAll();
+    }
+
+    @Override
+    public List<Task> findAllByUser(Long userId) {
+        return repo.findAllByParticipants_Id(userId);
+    }
+
     /* ===== REST / AJAX (заглушки) ===== */
 
     @Override

--- a/demo/src/main/resources/templates/fragments/header.html
+++ b/demo/src/main/resources/templates/fragments/header.html
@@ -27,6 +27,13 @@
         </li>
         <li class="nav-item">
           <a class="nav-link"
+             th:href="@{/tasks}"
+             th:classappend="${activePage} == 'tasks' ? ' active'">
+            Задачи
+          </a>
+        </li>
+        <li class="nav-item">
+          <a class="nav-link"
              th:href="@{/teams}"
              th:classappend="${activePage} == 'teams' ? ' active'">
             Команды

--- a/demo/src/main/resources/templates/task/all.html
+++ b/demo/src/main/resources/templates/task/all.html
@@ -1,0 +1,53 @@
+<!-- src/main/resources/templates/task/all.html -->
+<!DOCTYPE html>
+<html lang="ru"
+      xmlns:th="http://www.thymeleaf.org"
+      xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
+      layout:decorate="~{layout}">
+<head>
+    <meta charset="UTF-8"/>
+    <title layout:fragment="title" th:text="${title}">Задачи</title>
+</head>
+<body>
+<div layout:fragment="content">
+    <div class="container mt-4">
+        <div class="card shadow-sm">
+            <div class="card-header bg-primary text-white">
+                <h3 class="mb-0" th:text="${title}">Задачи</h3>
+            </div>
+            <div class="table-responsive">
+                <table class="table table-hover mb-0">
+                    <thead class="table-light">
+                    <tr>
+                        <th>Название</th>
+                        <th>Статус</th>
+                        <th>Проект</th>
+                        <th>Исполнители</th>
+                        <th></th>
+                    </tr>
+                    </thead>
+                    <tbody>
+                    <tr th:each="t : ${tasks}">
+                        <td th:text="${t.title}">title</td>
+                        <td th:text="${t.status}">status</td>
+                        <td>
+                            <a th:href="@{|/projects/${t.project.id}/view|}" th:text="${t.project.name}">Проект</a>
+                        </td>
+                        <td th:text="${#strings.listJoin(t.participants.?[username], ', ')}">-</td>
+                        <td class="text-end">
+                            <a th:href="@{|/projects/${t.project.id}/tasks/${t.id}|}" class="btn btn-sm btn-outline-secondary">
+                                <i class="bi bi-eye"></i>
+                            </a>
+                        </td>
+                    </tr>
+                    <tr th:if="${#lists.isEmpty(tasks)}">
+                        <td colspan="5" class="text-center py-3">Задач нет</td>
+                    </tr>
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </div>
+</div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add participants ManyToMany for tasks and users
- list all tasks on new `/tasks` page
- expose repository/service methods for listing tasks
- link to tasks page in navigation

## Testing
- `mvn -q -DskipTests package` *(fails: Could not download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684164c15dd4832a98280f7bc7eff291