### PR TITLE
Fix team list actions and update detail pages

### DIFF
--- a/demo/src/main/resources/templates/project/details.html
+++ b/demo/src/main/resources/templates/project/details.html
@@ -16,6 +16,11 @@
 <body>
 <div layout:fragment="content">
   <div class="container mt-4">
+    <div class="row justify-content-center">
+      <div class="col-md-8">
+        <h2 class="text-center mb-4">Детальная страница проекта</h2>
+      </div>
+    </div>
 
     <!-- ======= Карточка проекта ======= -->
     <div class="card shadow-sm mb-4">

--- a/demo/src/main/resources/templates/task/details.html
+++ b/demo/src/main/resources/templates/task/details.html
@@ -16,6 +16,11 @@
 <body>
 <div layout:fragment="content">
   <div class="container mt-4">
+    <div class="row justify-content-center">
+      <div class="col-md-8">
+        <h2 class="text-center mb-4">Детальная страница задачи</h2>
+      </div>
+    </div>
 
     <!-- ===== Карточка задачи ===== -->
     <div class="card shadow-sm mb-4">

--- a/demo/src/main/resources/templates/team/form.html
+++ b/demo/src/main/resources/templates/team/form.html
@@ -1,132 +1,62 @@
-<!-- src/main/resources/templates/project/form.html -->
 <!DOCTYPE html>
-<html lang="ru"
-      xmlns:th="http://www.thymeleaf.org"
+<html lang="ru" xmlns:th="http://www.thymeleaf.org"
       xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
       layout:decorate="~{layout}">
 <head>
-  <meta charset="UTF-8"/>
-  <meta name="viewport" content="width=device-width, initial-scale=1"/>
-  <title layout:fragment="title"
-         th:text="${title} ?: 'Форма проекта'">Форма проекта</title>
-  <!-- Если Bootstrap не подключён в ваш layout.html, раскомментируйте следующую строку: -->
-  <!-- <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet"/> -->
+    <meta charset="UTF-8"/>
+    <title layout:fragment="title" th:text="${title}">Форма команды</title>
 </head>
 <body>
-<!-- Всё внутри этого div попадёт в <main layout:fragment="content"> вашего layout.html -->
 <div layout:fragment="content" class="container py-4">
-  <div class="row justify-content-center">
-    <div class="col-md-8">
-      <div class="card shadow-sm">
-        <div class="card-header bg-primary text-white">
-          <h3 class="mb-0" th:text="${title}">Форма проекта</h3>
+    <div class="row justify-content-center">
+        <div class="col-md-8">
+            <div class="card shadow-sm">
+                <div class="card-header bg-primary text-white">
+                    <h3 class="mb-0" th:text="${title}">Форма команды</h3>
+                </div>
+                <div class="card-body">
+                    <form th:action="@{/teams/save}" th:object="${team}" method="post" class="needs-validation" novalidate>
+                        <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}"/>
+                        <input type="hidden" th:if="${team.id != null}" th:field="*{id}"/>
+
+                        <div class="mb-3">
+                            <label for="name" class="form-label">Название</label>
+                            <input type="text" id="name" class="form-control" th:field="*{name}" placeholder="Введите название команды" required/>
+                            <div class="invalid-feedback">Пожалуйста, введите название команды.</div>
+                            <div class="text-danger mt-1" th:if="${#fields.hasErrors('name')}" th:errors="*{name}"></div>
+                        </div>
+
+                        <div class="mb-3">
+                            <label for="description" class="form-label">Описание</label>
+                            <textarea id="description" th:field="*{description}" class="form-control" rows="4" placeholder="Описание команды"></textarea>
+                        </div>
+
+                        <div class="d-flex">
+                            <button type="submit" class="btn btn-primary me-2">
+                                <span th:text="${team.id == null} ? 'Сохранить' : 'Обновить'">Сохранить</span>
+                            </button>
+                            <a th:href="@{/teams}" class="btn btn-outline-secondary">Отмена</a>
+                        </div>
+                    </form>
+                </div>
+            </div>
         </div>
-        <div class="card-body">
-          <form th:action="@{/projects}"
-                th:object="${project}"
-                method="post"
-                class="needs-validation"
-                novalidate>
-            <!-- CSRF-токен (Spring Security) -->
-            <input type="hidden"
-                   th:name="${_csrf.parameterName}"
-                   th:value="${_csrf.token}"/>
-
-            <!-- Если проект уже существует (p.id != null), прячем его id -->
-            <input type="hidden"
-                   th:if="${project.id != null}"
-                   th:field="*{id}"/>
-
-            <!-- Название -->
-            <div class="mb-3">
-              <label for="name" class="form-label">Название</label>
-              <input type="text"
-                     id="name"
-                     th:field="*{name}"
-                     class="form-control"
-                     placeholder="Введите название проекта"
-                     required/>
-              <div class="invalid-feedback">
-                Пожалуйста, введите название проекта.
-              </div>
-              <div class="text-danger mt-1"
-                   th:if="${#fields.hasErrors('name')}"
-                   th:errors="*{name}"></div>
-            </div>
-
-            <!-- Описание (необязательно) -->
-            <div class="mb-3">
-              <label for="description" class="form-label">Описание</label>
-              <textarea id="description"
-                        th:field="*{description}"
-                        class="form-control"
-                        rows="4"
-                        placeholder="Введите описание проекта"></textarea>
-            </div>
-
-            <!-- Радиокнопки: Личный vs Командный проект -->
-            <div class="mb-4">
-              <label class="form-label d-block">Тип проекта</label>
-
-              <!-- 1) Личный проект: всегда можно выбрать -->
-              <div class="form-check form-check-inline">
-                <input class="form-check-input"
-                       type="radio"
-                       name="projectType"
-                       id="privateRadio"
-                       value="PRIVATE"
-                       th:checked="${project.team == null}"/>
-                <label class="form-check-label" for="privateRadio">
-                  Личный проект
-                </label>
-              </div>
-
-              <!-- 2) Командный проект: показываем только если у пользователя есть команда (hasTeam == true) -->
-              <div class="form-check form-check-inline" th:if="${hasTeam}">
-                <input class="form-check-input"
-                       type="radio"
-                       name="projectType"
-                       id="teamRadio"
-                       value="TEAM"
-                       th:checked="${project.team != null}"/>
-                <label class="form-check-label" for="teamRadio">
-                  Командный проект
-                </label>
-              </div>
-            </div>
-
-            <!-- Кнопки: Сохранить / Отмена -->
-            <div class="d-flex">
-              <button type="submit" class="btn btn-primary me-2">
-                <span th:text="${project.id == null} ? 'Сохранить' : 'Обновить'">Сохранить</span>
-              </button>
-              <a th:href="@{/projects}" class="btn btn-outline-secondary">Отмена</a>
-            </div>
-          </form>
-        </div>
-      </div>
     </div>
-  </div>
-</div> <!-- /content -->
-
-<!-- Скрипт Bootstrap-валидации -->
+</div>
 <script>
-  (function () {
-    'use strict';
-    const forms = document.querySelectorAll('.needs-validation');
-    Array.from(forms).forEach(function (form) {
-      form.addEventListener('submit', function (event) {
-        if (!form.checkValidity()) {
-          event.preventDefault();
-          event.stopPropagation();
-        }
-        form.classList.add('was-validated');
-      }, false);
-    });
-  })();
+    (function () {
+        'use strict';
+        const forms = document.querySelectorAll('.needs-validation');
+        Array.from(forms).forEach(function (form) {
+            form.addEventListener('submit', function (event) {
+                if (!form.checkValidity()) {
+                    event.preventDefault();
+                    event.stopPropagation();
+                }
+                form.classList.add('was-validated');
+            }, false);
+        });
+    })();
 </script>
-
-<!-- Если Bootstrap.js не подключён в layout.html, можно раскомментировать: -->
-<!-- <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script> -->
 </body>
 </html>

--- a/demo/src/main/resources/templates/team/list.html
+++ b/demo/src/main/resources/templates/team/list.html
@@ -45,19 +45,6 @@
                                             <i class="bi bi-eye me-1"></i> Просмотреть
                                         </a>
 
-                                        <!-- Кнопка «Редактировать» для ADMIN -->
-                                        <a th:if="${#authorization.expression('hasRole(''ROLE_ADMIN'')')}"
-                                           th:href="@{|/teams/${t.id}/edit|}"
-                                           class="btn btn-sm btn-outline-secondary me-2 mb-1">
-                                            <i class="bi bi-pencil me-1"></i> Ред.
-                                        </a>
-
-                                        <!-- Кнопка «Добавить участника» для ADMIN -->
-                                        <a th:if="${#authorization.expression('hasRole(''ROLE_ADMIN'')')}"
-                                           th:href="@{|/teams/${t.id}/add-user|}"
-                                           class="btn btn-sm btn-outline-success me-2 mb-1">
-                                            <i class="bi bi-person-plus me-1"></i> Добавить
-                                        </a>
 
                                         <!-- Форма «Удалить» для ADMIN -->
                                         <form th:if="${#authorization.expression('hasRole(''ROLE_ADMIN'')')}"


### PR DESCRIPTION
## Summary
- show only View/Delete options on team list
- create dedicated team edit form
- emphasize headings on project/task detail pages

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68416de4b4e0832ab61de62ac885c241