### PR TITLE
Fix team list actions and update detail pages

### DIFF
--- a/demo/src/main/java/itis/semestrovka/demo/controller/TeamController.java
+++ b/demo/src/main/java/itis/semestrovka/demo/controller/TeamController.java
@@ -73,14 +73,25 @@ public class TeamController {
     @PreAuthorize("hasRole('ROLE_ADMIN')")
     @PostMapping("/save")
     public String save(
-            @Valid @ModelAttribute("team") Team team,
+            @Valid @ModelAttribute("team") Team formTeam,
             BindingResult br,
             Model model
     ) {
         if (br.hasErrors()) {
-            model.addAttribute("title", (team.getId() == null) ? "Новая команда" : "Редактирование команды");
+            model.addAttribute("title",
+                    (formTeam.getId() == null) ? "Новая команда" : "Редактирование команды");
             return "team/form";
         }
+
+        Team team;
+        if (formTeam.getId() != null) {
+            team = teamService.findById(formTeam.getId());
+            team.setName(formTeam.getName());
+            team.setDescription(formTeam.getDescription());
+        } else {
+            team = formTeam;
+        }
+
         teamService.create(team);
         return "redirect:/teams/admin";
     }

--- a/demo/src/main/java/itis/semestrovka/demo/controller/TeamRestController.java
+++ b/demo/src/main/java/itis/semestrovka/demo/controller/TeamRestController.java
@@ -1,0 +1,26 @@
+package itis.semestrovka.demo.controller;
+
+import itis.semestrovka.demo.service.TeamService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/teams")
+@RequiredArgsConstructor
+@PreAuthorize("hasRole('ROLE_ADMIN')")
+public class TeamRestController {
+
+    private final TeamService teamService;
+
+    /** Удаление пользователя из команды через AJAX */
+    @DeleteMapping("/{teamId}/users/{userId}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void removeUser(
+            @PathVariable Long teamId,
+            @PathVariable Long userId
+    ) {
+        teamService.removeUserFromTeam(teamId, userId);
+    }
+}

--- a/demo/src/main/resources/static/css/style.css
+++ b/demo/src/main/resources/static/css/style.css
@@ -1,37 +1,51 @@
 
 body {
-    background: linear-gradient(135deg, #f8fafc 0%, #e0e7ff 100%);
+    font-family: 'Inter', sans-serif;
+    background: linear-gradient(135deg, #fdfcfb 0%, #e2e2e2 100%);
     min-height: 100vh;
 }
-.navbar, .footer {
-    background: #312e81;
+
+.navbar,
+.footer {
+    background: linear-gradient(90deg, #4f46e5, #9333ea);
 }
-.navbar a, .footer {
-    color: #f8fafc !important;
+
+.navbar a,
+.footer {
+    color: #ffffff !important;
 }
+
 .card {
     border: none;
-    border-radius: 1.5rem;
-    box-shadow: 0 6px 40px 0 rgba(0, 0, 0, 0.10);
+    border-radius: 1rem;
+    box-shadow: 0 6px 24px rgba(0, 0, 0, 0.08);
     transition: transform .12s;
 }
+
+.card:hover {
+    transform: translateY(-2px);
+}
+
 .btn-main {
-    background: #6366f1;
-    color: white;
-    border-radius: 1.5rem;
+    background: #4f46e5;
+    color: #fff;
+    border-radius: .5rem;
     font-weight: 500;
     transition: background .15s;
 }
+
 .btn-main:hover {
     background: #4338ca;
     color: #fff;
 }
+
 .footer {
-    font-size: 1rem;
+    font-size: 0.95rem;
     letter-spacing: 0.05em;
     margin-top: 48px;
-    border-radius: 1.5rem 1.5rem 0 0;
+    border-radius: 1rem 1rem 0 0;
 }
+
 main {
     margin-top: 2rem;
 }

--- a/demo/src/main/resources/templates/fragments/footer.html
+++ b/demo/src/main/resources/templates/fragments/footer.html
@@ -1,5 +1,5 @@
 <!-- templates/fragments/footer.html -->
-<footer th:fragment="footer" class="bg-light border-top mt-5">
+<footer th:fragment="footer" class="mt-5 footer">
   <div class="container">
     <div class="row">
       <div class="col text-center py-3">

--- a/demo/src/main/resources/templates/fragments/header.html
+++ b/demo/src/main/resources/templates/fragments/header.html
@@ -2,7 +2,7 @@
 <nav th:fragment="header"
      xmlns:th="http://www.thymeleaf.org"
      xmlns:sec="https://www.thymeleaf.org/thymeleaf-extras-springsecurity6"
-     class="navbar navbar-expand-lg navbar-dark bg-primary shadow-sm">
+     class="navbar navbar-expand-lg navbar-dark shadow-sm">
   <div class="container">
     <a class="navbar-brand" th:href="@{/}">
       <i class="bi bi-people-fill me-1"></i> TeamManager

--- a/demo/src/main/resources/templates/layout.html
+++ b/demo/src/main/resources/templates/layout.html
@@ -7,6 +7,8 @@
   <meta charset="UTF-8"/>
   <meta name="viewport" content="width=device-width, initial-scale=1"/>
   <title th:text="${title} ?: 'TeamManager'">TeamManager</title>
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet"/>
   <link rel="stylesheet" th:href="@{/css/style.css}"/>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css"/>

--- a/demo/src/main/resources/templates/project/details.html
+++ b/demo/src/main/resources/templates/project/details.html
@@ -16,6 +16,11 @@
 <body>
 <div layout:fragment="content">
   <div class="container mt-4">
+    <div class="row justify-content-center">
+      <div class="col-md-8">
+        <h2 class="text-center mb-4">Детальная страница проекта</h2>
+      </div>
+    </div>
 
     <!-- ======= Карточка проекта ======= -->
     <div class="card shadow-sm mb-4">
@@ -27,29 +32,29 @@
       </div>
 
       <div class="card-body">
-        <p><strong>ID:</strong> <span th:text="${project.id}">1</span></p>
-        <p><strong>Название:</strong> <span th:text="${project.name}">Название</span></p>
-        <p><strong>Описание:</strong> <span th:text="${project.description}">Описание</span></p>
-        <p><strong>Владелец:</strong> <span th:text="${project.owner.username}">owner</span></p>
+        <dl class="row mb-0">
+          <dt class="col-sm-4">Название</dt>
+          <dd class="col-sm-8" th:text="${project.name}">Название</dd>
 
-        <p><strong>Приоритет:</strong>
-          <span th:switch="${project.priority}">
-            <span th:case="1">Низкий</span>
-            <span th:case="2">Средний</span>
-            <span th:case="3">Высокий</span>
-            <span th:case="*">—</span>
-          </span>
-        </p>
+          <dt class="col-sm-4">Описание</dt>
+          <dd class="col-sm-8" th:text="${project.description}">Описание</dd>
 
-        <p><strong>Команда:</strong>
-          <span th:text="${project.team != null ? project.team.name : '—'}">—</span>
-        </p>
+          <dt class="col-sm-4">Владелец</dt>
+          <dd class="col-sm-8" th:text="${project.owner.username}">owner</dd>
 
-        <p><strong>Дата создания:</strong>
-          <span th:text="${#temporals.format(project.createdAt,'dd.MM.yyyy HH:mm')}">
-            01.01.2025 00:00
-          </span>
-        </p>
+          <dt class="col-sm-4">Приоритет</dt>
+          <dd class="col-sm-8">
+            <span th:switch="${project.priority}">
+              <span th:case="1">Низкий</span>
+              <span th:case="2">Средний</span>
+              <span th:case="3">Высокий</span>
+              <span th:case="*">—</span>
+            </span>
+          </dd>
+
+          <dt class="col-sm-4">Команда</dt>
+          <dd class="col-sm-8" th:text="${project.team != null ? project.team.name : '—'}">—</dd>
+        </dl>
       </div>
 
       <div class="card-footer d-flex justify-content-between">
@@ -189,7 +194,7 @@
 <script th:inline="javascript">
   /*<![CDATA[*/
   const projectId  = /*[[${project.id}]]*/ 0;
-  const csrfHeader = 'X-CSRF-TOKEN';
+  const csrfHeader = /*[['${_csrf.headerName}']]*/ 'X-CSRF-TOKEN';
   const csrfToken  = /*[['${_csrf.token}']]*/ '';
 
   // ---------- открыть модалку ----------

--- a/demo/src/main/resources/templates/task/details.html
+++ b/demo/src/main/resources/templates/task/details.html
@@ -16,6 +16,11 @@
 <body>
 <div layout:fragment="content">
   <div class="container mt-4">
+    <div class="row justify-content-center">
+      <div class="col-md-8">
+        <h2 class="text-center mb-4">Детальная страница задачи</h2>
+      </div>
+    </div>
 
     <!-- ===== Карточка задачи ===== -->
     <div class="card shadow-sm mb-4">
@@ -24,24 +29,21 @@
       </div>
 
       <div class="card-body">
-        <p><strong>ID:</strong> <span th:text="${task.id}">1</span></p>
-        <p><strong>Статус:</strong> <span th:text="${task.status}">TODO</span></p>
-        <p><strong>Описание:</strong> <span th:text="${task.description}">—</span></p>
+        <dl class="row mb-0">
+          <dt class="col-sm-4">Статус</dt>
+          <dd class="col-sm-8" th:text="${task.status}">TODO</dd>
 
-        <p><strong>Исполнитель:</strong>
-          <span th:text="${task.assignedUser != null ? task.assignedUser.username : '—'}">—</span>
-        </p>
+          <dt class="col-sm-4">Описание</dt>
+          <dd class="col-sm-8" th:text="${task.description}">—</dd>
 
-        <p><strong>Проект:</strong>
-          <a th:href="@{|/projects/${project.id}/view|}"
-             th:text="${project.name}">Проект</a>
-        </p>
+          <dt class="col-sm-4">Исполнитель</dt>
+          <dd class="col-sm-8" th:text="${task.assignedUser != null ? task.assignedUser.username : '—'}">—</dd>
 
-        <p><strong>Дата создания:</strong>
-          <span th:text="${#temporals.format(task.createdAt,'dd.MM.yyyy HH:mm')}">
-            01.01.2025 00:00
-          </span>
-        </p>
+          <dt class="col-sm-4">Проект</dt>
+          <dd class="col-sm-8">
+            <a th:href="@{|/projects/${project.id}/view|}" th:text="${project.name}">Проект</a>
+          </dd>
+        </dl>
       </div>
 
       <!-- ==== Кнопки ==== -->

--- a/demo/src/main/resources/templates/team/form.html
+++ b/demo/src/main/resources/templates/team/form.html
@@ -1,132 +1,62 @@
-<!-- src/main/resources/templates/project/form.html -->
 <!DOCTYPE html>
-<html lang="ru"
-      xmlns:th="http://www.thymeleaf.org"
+<html lang="ru" xmlns:th="http://www.thymeleaf.org"
       xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
       layout:decorate="~{layout}">
 <head>
-  <meta charset="UTF-8"/>
-  <meta name="viewport" content="width=device-width, initial-scale=1"/>
-  <title layout:fragment="title"
-         th:text="${title} ?: 'Форма проекта'">Форма проекта</title>
-  <!-- Если Bootstrap не подключён в ваш layout.html, раскомментируйте следующую строку: -->
-  <!-- <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet"/> -->
+    <meta charset="UTF-8"/>
+    <title layout:fragment="title" th:text="${title}">Форма команды</title>
 </head>
 <body>
-<!-- Всё внутри этого div попадёт в <main layout:fragment="content"> вашего layout.html -->
 <div layout:fragment="content" class="container py-4">
-  <div class="row justify-content-center">
-    <div class="col-md-8">
-      <div class="card shadow-sm">
-        <div class="card-header bg-primary text-white">
-          <h3 class="mb-0" th:text="${title}">Форма проекта</h3>
+    <div class="row justify-content-center">
+        <div class="col-md-8">
+            <div class="card shadow-sm">
+                <div class="card-header bg-primary text-white">
+                    <h3 class="mb-0" th:text="${title}">Форма команды</h3>
+                </div>
+                <div class="card-body">
+                    <form th:action="@{/teams/save}" th:object="${team}" method="post" class="needs-validation" novalidate>
+                        <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}"/>
+                        <input type="hidden" th:if="${team.id != null}" th:field="*{id}"/>
+
+                        <div class="mb-3">
+                            <label for="name" class="form-label">Название</label>
+                            <input type="text" id="name" class="form-control" th:field="*{name}" placeholder="Введите название команды" required/>
+                            <div class="invalid-feedback">Пожалуйста, введите название команды.</div>
+                            <div class="text-danger mt-1" th:if="${#fields.hasErrors('name')}" th:errors="*{name}"></div>
+                        </div>
+
+                        <div class="mb-3">
+                            <label for="description" class="form-label">Описание</label>
+                            <textarea id="description" th:field="*{description}" class="form-control" rows="4" placeholder="Описание команды"></textarea>
+                        </div>
+
+                        <div class="d-flex">
+                            <button type="submit" class="btn btn-primary me-2">
+                                <span th:text="${team.id == null} ? 'Сохранить' : 'Обновить'">Сохранить</span>
+                            </button>
+                            <a th:href="@{/teams}" class="btn btn-outline-secondary">Отмена</a>
+                        </div>
+                    </form>
+                </div>
+            </div>
         </div>
-        <div class="card-body">
-          <form th:action="@{/projects}"
-                th:object="${project}"
-                method="post"
-                class="needs-validation"
-                novalidate>
-            <!-- CSRF-токен (Spring Security) -->
-            <input type="hidden"
-                   th:name="${_csrf.parameterName}"
-                   th:value="${_csrf.token}"/>
-
-            <!-- Если проект уже существует (p.id != null), прячем его id -->
-            <input type="hidden"
-                   th:if="${project.id != null}"
-                   th:field="*{id}"/>
-
-            <!-- Название -->
-            <div class="mb-3">
-              <label for="name" class="form-label">Название</label>
-              <input type="text"
-                     id="name"
-                     th:field="*{name}"
-                     class="form-control"
-                     placeholder="Введите название проекта"
-                     required/>
-              <div class="invalid-feedback">
-                Пожалуйста, введите название проекта.
-              </div>
-              <div class="text-danger mt-1"
-                   th:if="${#fields.hasErrors('name')}"
-                   th:errors="*{name}"></div>
-            </div>
-
-            <!-- Описание (необязательно) -->
-            <div class="mb-3">
-              <label for="description" class="form-label">Описание</label>
-              <textarea id="description"
-                        th:field="*{description}"
-                        class="form-control"
-                        rows="4"
-                        placeholder="Введите описание проекта"></textarea>
-            </div>
-
-            <!-- Радиокнопки: Личный vs Командный проект -->
-            <div class="mb-4">
-              <label class="form-label d-block">Тип проекта</label>
-
-              <!-- 1) Личный проект: всегда можно выбрать -->
-              <div class="form-check form-check-inline">
-                <input class="form-check-input"
-                       type="radio"
-                       name="projectType"
-                       id="privateRadio"
-                       value="PRIVATE"
-                       th:checked="${project.team == null}"/>
-                <label class="form-check-label" for="privateRadio">
-                  Личный проект
-                </label>
-              </div>
-
-              <!-- 2) Командный проект: показываем только если у пользователя есть команда (hasTeam == true) -->
-              <div class="form-check form-check-inline" th:if="${hasTeam}">
-                <input class="form-check-input"
-                       type="radio"
-                       name="projectType"
-                       id="teamRadio"
-                       value="TEAM"
-                       th:checked="${project.team != null}"/>
-                <label class="form-check-label" for="teamRadio">
-                  Командный проект
-                </label>
-              </div>
-            </div>
-
-            <!-- Кнопки: Сохранить / Отмена -->
-            <div class="d-flex">
-              <button type="submit" class="btn btn-primary me-2">
-                <span th:text="${project.id == null} ? 'Сохранить' : 'Обновить'">Сохранить</span>
-              </button>
-              <a th:href="@{/projects}" class="btn btn-outline-secondary">Отмена</a>
-            </div>
-          </form>
-        </div>
-      </div>
     </div>
-  </div>
-</div> <!-- /content -->
-
-<!-- Скрипт Bootstrap-валидации -->
+</div>
 <script>
-  (function () {
-    'use strict';
-    const forms = document.querySelectorAll('.needs-validation');
-    Array.from(forms).forEach(function (form) {
-      form.addEventListener('submit', function (event) {
-        if (!form.checkValidity()) {
-          event.preventDefault();
-          event.stopPropagation();
-        }
-        form.classList.add('was-validated');
-      }, false);
-    });
-  })();
+    (function () {
+        'use strict';
+        const forms = document.querySelectorAll('.needs-validation');
+        Array.from(forms).forEach(function (form) {
+            form.addEventListener('submit', function (event) {
+                if (!form.checkValidity()) {
+                    event.preventDefault();
+                    event.stopPropagation();
+                }
+                form.classList.add('was-validated');
+            }, false);
+        });
+    })();
 </script>
-
-<!-- Если Bootstrap.js не подключён в layout.html, можно раскомментировать: -->
-<!-- <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script> -->
 </body>
 </html>

--- a/demo/src/main/resources/templates/team/list.html
+++ b/demo/src/main/resources/templates/team/list.html
@@ -45,19 +45,6 @@
                                             <i class="bi bi-eye me-1"></i> Просмотреть
                                         </a>
 
-                                        <!-- Кнопка «Редактировать» для ADMIN -->
-                                        <a th:if="${#authorization.expression('hasRole(''ROLE_ADMIN'')')}"
-                                           th:href="@{|/teams/${t.id}/edit|}"
-                                           class="btn btn-sm btn-outline-secondary me-2 mb-1">
-                                            <i class="bi bi-pencil me-1"></i> Ред.
-                                        </a>
-
-                                        <!-- Кнопка «Добавить участника» для ADMIN -->
-                                        <a th:if="${#authorization.expression('hasRole(''ROLE_ADMIN'')')}"
-                                           th:href="@{|/teams/${t.id}/add-user|}"
-                                           class="btn btn-sm btn-outline-success me-2 mb-1">
-                                            <i class="bi bi-person-plus me-1"></i> Добавить
-                                        </a>
 
                                         <!-- Форма «Удалить» для ADMIN -->
                                         <form th:if="${#authorization.expression('hasRole(''ROLE_ADMIN'')')}"

--- a/demo/src/main/resources/templates/team/view.html
+++ b/demo/src/main/resources/templates/team/view.html
@@ -65,17 +65,12 @@
                 <tr th:each="u : ${team.members}">
                   <td th:text="${u.username}">username</td>
                   <td>
-                    <form th:if="${#authorization.expression('hasRole(''ROLE_ADMIN'')')}"
-                          th:action="@{|/teams/${team.id}/remove-user|}"
-                          method="post">
-                      <input type="hidden"
-                             th:name="${_csrf.parameterName}"
-                             th:value="${_csrf.token}" />
-                      <input type="hidden" name="userId" th:value="${u.id}" />
-                      <button type="submit" class="btn btn-sm btn-outline-danger">
-                        <i class="bi bi-person-dash me-1"></i> Убрать
-                      </button>
-                    </form>
+                    <button th:if="${#authorization.expression('hasRole(''ROLE_ADMIN'')')}"
+                            type="button"
+                            class="btn btn-sm btn-outline-danger js-remove-user"
+                            th:data-user-id="${u.id}">
+                      <i class="bi bi-person-dash me-1"></i> Убрать
+                    </button>
                   </td>
                 </tr>
                 <tr th:if="${#lists.isEmpty(team.members)}">
@@ -96,5 +91,28 @@
     </div>
   </div>
 </div>
+<script th:inline="javascript">
+  /*<![CDATA[*/
+  const teamId   = /*[[${team.id}]]*/ 0;
+  const csrfHdr  = /*[['${_csrf.headerName}']]*/ 'X-CSRF-TOKEN';
+  const csrfTok  = /*[['${_csrf.token}']]*/ '';
+
+  document.querySelectorAll('.js-remove-user').forEach(btn => {
+    btn.addEventListener('click', async e => {
+      e.preventDefault();
+      const userId = btn.dataset.userId;
+      const resp = await fetch(`/api/teams/${teamId}/users/${userId}`, {
+        method : 'DELETE',
+        headers: { [csrfHdr]: csrfTok }
+      });
+      if (resp.ok) {
+        btn.closest('tr').remove();
+      } else {
+        alert('Ошибка удаления пользователя');
+      }
+    });
+  });
+  /*]]>*/
+</script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- show only View/Delete options on team list
- create dedicated team edit form
- emphasize headings on project/task detail pages
- improved overall styling and font with Inter
- REST calls now use CSRF header name dynamically

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68416de4b4e0832ab61de62ac885c241