### PR TITLE
Add user profile feature

### DIFF
--- a/demo/src/main/java/itis/semestrovka/demo/controller/UserProfileController.java
+++ b/demo/src/main/java/itis/semestrovka/demo/controller/UserProfileController.java
@@ -1,0 +1,41 @@
+package itis.semestrovka.demo.controller;
+
+import itis.semestrovka.demo.model.entity.User;
+import itis.semestrovka.demo.model.entity.UserProfile;
+import itis.semestrovka.demo.service.UserProfileService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+
+@Controller
+@RequiredArgsConstructor
+public class UserProfileController {
+
+    private final UserProfileService profileService;
+
+    @GetMapping("/profile")
+    public String view(@AuthenticationPrincipal User currentUser, Model model) {
+        UserProfile profile = profileService.findByUserId(currentUser.getId());
+        model.addAttribute("profile", profile);
+        model.addAttribute("title", "Профиль");
+        return "profile/view";
+    }
+
+    @GetMapping("/profile/edit")
+    public String editForm(@AuthenticationPrincipal User currentUser, Model model) {
+        UserProfile profile = profileService.findByUserId(currentUser.getId());
+        model.addAttribute("profile", profile);
+        model.addAttribute("title", "Редактировать профиль");
+        return "profile/form";
+    }
+
+    @PostMapping("/profile")
+    public String save(@AuthenticationPrincipal User currentUser, UserProfile profile) {
+        profile.setUser(currentUser);
+        profileService.save(profile);
+        return "redirect:/profile";
+    }
+}

--- a/demo/src/main/java/itis/semestrovka/demo/model/entity/User.java
+++ b/demo/src/main/java/itis/semestrovka/demo/model/entity/User.java
@@ -41,6 +41,10 @@ public class User implements UserDetails {
     @ManyToMany(mappedBy = "participants")
     private Set<Task> tasks = new HashSet<>();
 
+    // Профиль пользователя
+    @OneToOne(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+    private UserProfile profile;
+
     // --- UserDetails implementation ---
     @Override public Collection<Role> getAuthorities() { return Collections.singleton(role); }
     @Override public boolean isAccountNonExpired()  { return true; }

--- a/demo/src/main/java/itis/semestrovka/demo/model/entity/UserProfile.java
+++ b/demo/src/main/java/itis/semestrovka/demo/model/entity/UserProfile.java
@@ -1,0 +1,24 @@
+package itis.semestrovka.demo.model.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Table(name = "user_profiles")
+@Getter
+@Setter
+@NoArgsConstructor
+public class UserProfile {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String fullName;
+    private String bio;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", unique = true)
+    private User user;
+}

--- a/demo/src/main/java/itis/semestrovka/demo/repository/UserProfileRepository.java
+++ b/demo/src/main/java/itis/semestrovka/demo/repository/UserProfileRepository.java
@@ -1,0 +1,12 @@
+package itis.semestrovka.demo.repository;
+
+import itis.semestrovka.demo.model.entity.UserProfile;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface UserProfileRepository extends JpaRepository<UserProfile, Long> {
+    Optional<UserProfile> findByUser_Id(Long userId);
+}

--- a/demo/src/main/java/itis/semestrovka/demo/service/UserProfileService.java
+++ b/demo/src/main/java/itis/semestrovka/demo/service/UserProfileService.java
@@ -1,0 +1,8 @@
+package itis.semestrovka.demo.service;
+
+import itis.semestrovka.demo.model.entity.UserProfile;
+
+public interface UserProfileService {
+    UserProfile findByUserId(Long userId);
+    UserProfile save(UserProfile profile);
+}

--- a/demo/src/main/java/itis/semestrovka/demo/service/impl/UserProfileServiceImpl.java
+++ b/demo/src/main/java/itis/semestrovka/demo/service/impl/UserProfileServiceImpl.java
@@ -1,0 +1,32 @@
+package itis.semestrovka.demo.service.impl;
+
+import itis.semestrovka.demo.model.entity.UserProfile;
+import itis.semestrovka.demo.repository.UserProfileRepository;
+import itis.semestrovka.demo.repository.UserRepository;
+import itis.semestrovka.demo.service.UserProfileService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class UserProfileServiceImpl implements UserProfileService {
+
+    private final UserProfileRepository repo;
+    private final UserRepository userRepo;
+
+    @Override
+    public UserProfile findByUserId(Long userId) {
+        return repo.findByUser_Id(userId).orElseGet(() -> {
+            UserProfile p = new UserProfile();
+            p.setUser(userRepo.findById(userId).orElseThrow());
+            return repo.save(p);
+        });
+    }
+
+    @Override
+    public UserProfile save(UserProfile profile) {
+        return repo.save(profile);
+    }
+}

--- a/demo/src/main/resources/templates/fragments/header.html
+++ b/demo/src/main/resources/templates/fragments/header.html
@@ -67,6 +67,9 @@
           </span>
         </li>
         <li class="nav-item">
+          <a class="nav-link" th:href="@{/profile}" th:classappend="${activePage} == 'profile' ? ' active'">Профиль</a>
+        </li>
+        <li class="nav-item">
           <form th:action="@{/logout}" method="post" class="d-flex align-items-center">
             <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}"/>
             <button type="submit" class="btn btn-link nav-link">Выйти</button>

--- a/demo/src/main/resources/templates/profile/form.html
+++ b/demo/src/main/resources/templates/profile/form.html
@@ -1,0 +1,42 @@
+<!-- src/main/resources/templates/profile/form.html -->
+<!DOCTYPE html>
+<html lang="ru"
+      xmlns:th="http://www.thymeleaf.org"
+      xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
+      layout:decorate="~{layout}">
+<head>
+  <title layout:fragment="title" th:text="${title}">Редактировать профиль</title>
+</head>
+<body>
+<div layout:fragment="content">
+  <div class="container">
+    <div class="row justify-content-center">
+      <div class="col-md-6">
+        <div class="card mt-5 shadow-sm">
+          <div class="card-header bg-primary text-white">
+            <h3 class="mb-0" th:text="${title}">Редактировать профиль</h3>
+          </div>
+          <div class="card-body">
+            <form th:action="@{/profile}" th:object="${profile}" method="post">
+              <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}"/>
+              <div class="mb-3">
+                <label for="fullName" class="form-label">Полное имя</label>
+                <input type="text" id="fullName" th:field="*{fullName}" class="form-control"/>
+              </div>
+              <div class="mb-3">
+                <label for="bio" class="form-label">Био</label>
+                <textarea id="bio" th:field="*{bio}" class="form-control" rows="3"></textarea>
+              </div>
+              <div class="d-flex">
+                <button type="submit" class="btn btn-success me-2">Сохранить</button>
+                <a th:href="@{/profile}" class="btn btn-secondary">Отмена</a>
+              </div>
+            </form>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+</body>
+</html>

--- a/demo/src/main/resources/templates/profile/view.html
+++ b/demo/src/main/resources/templates/profile/view.html
@@ -1,0 +1,34 @@
+<!-- src/main/resources/templates/profile/view.html -->
+<!DOCTYPE html>
+<html lang="ru"
+      xmlns:th="http://www.thymeleaf.org"
+      xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
+      layout:decorate="~{layout}">
+<head>
+  <title layout:fragment="title">Профиль</title>
+</head>
+<body>
+<div layout:fragment="content">
+  <div class="container">
+    <div class="row justify-content-center">
+      <div class="col-md-6">
+        <div class="card mt-5 shadow-sm">
+          <div class="card-header bg-primary text-white d-flex justify-content-between align-items-center">
+            <h3 class="mb-0">Профиль</h3>
+            <a th:href="@{/profile/edit}" class="btn btn-outline-light btn-sm">Редактировать</a>
+          </div>
+          <div class="card-body">
+            <dl class="row mb-0">
+              <dt class="col-sm-4">Имя</dt>
+              <dd class="col-sm-8" th:text="${profile.fullName}">—</dd>
+              <dt class="col-sm-4">О себе</dt>
+              <dd class="col-sm-8" th:text="${profile.bio}">—</dd>
+            </dl>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add `UserProfile` entity and relation with `User`
- create repository and service to manage profiles
- add controller and templates to view and edit a profile
- link profile page in the navigation header

## Testing
- `mvnw test -DskipTests` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68419494afac832aadfa95c6ed519b2f