### PR TITLE
Fix profile update causing unique constraint error

### DIFF
--- a/demo/src/main/resources/templates/profile/form.html
+++ b/demo/src/main/resources/templates/profile/form.html
@@ -141,6 +141,7 @@
           <div class="card-body">
             <form th:action="@{/profile}" th:object="${profile}" method="post">
               <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}"/>
+              <input type="hidden" th:if="${profile.id != null}" th:field="*{id}"/>
               <div class="form-group mb-3">
                 <label for="fullName">Полное имя</label>
                 <input type="text" id="fullName" th:field="*{fullName}"/>


### PR DESCRIPTION
## Summary
- include hidden `id` field in user profile form to update existing profile instead of inserting a duplicate

## Testing
- `./mvnw test -q` *(fails: Non-resolvable parent POM due to network)*

------
https://chatgpt.com/codex/tasks/task_e_6841c34ccdd0832a95c07b04ad7f707f