### PR TITLE
Implement task participant assignments

### DIFF
--- a/demo/src/main/resources/templates/task/details.html
+++ b/demo/src/main/resources/templates/task/details.html
@@ -65,6 +65,15 @@
           <td th:text="${task.assignedUser != null ? task.assignedUser.username : '—'}">123456</td>
         </tr>
         <tr>
+          <th>Участники</th>
+          <td>
+            <span th:if="${#lists.isEmpty(task.participants)}">—</span>
+            <span th:each="p,iter : ${task.participants}">
+              <span th:text="${p.username}"></span><span th:if="${!iter.last}">, </span>
+            </span>
+          </td>
+        </tr>
+        <tr>
           <th>Проект</th>
           <td>
             <a th:href="@{|/projects/${project.id}/view|}" th:text="${project.name}">Проект</a>

--- a/demo/src/main/resources/templates/task/form.html
+++ b/demo/src/main/resources/templates/task/form.html
@@ -68,6 +68,18 @@
             </select>
           </div>
 
+          <!-- Участники задачи -->
+          <div class="mb-3" th:if="${#lists.size(candidates) > 1}">
+            <label for="participantIds" class="form-label">Участники</label>
+            <select id="participantIds" name="participantIds" multiple class="form-select">
+              <option th:each="u : ${candidates}"
+                      th:value="${u.id}"
+                      th:text="${u.username}"
+                      th:selected="${task.participants.contains(u)}">
+              </option>
+            </select>
+          </div>
+
           <!-- Кнопки -->
           <div class="d-flex justify-content-between">
             <button type="submit" class="btn btn-primary">Сохранить</button>


### PR DESCRIPTION
## Summary
- allow selecting multiple users as task participants
- update TaskController to handle participantIds
- show participants in task details

## Testing
- `mvn -q -DskipTests package` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent)*

------
https://chatgpt.com/codex/tasks/task_e_684215645dc4832aa482081bb6547538