### PR TITLE
Implement task participant assignments

### DIFF
--- a/demo/src/main/resources/templates/project/details.html
+++ b/demo/src/main/resources/templates/project/details.html
@@ -32,7 +32,7 @@
         <a id="btnAddTask"
            class="btn-new-task"
            th:if="${project.owner.username == #authentication.name
-                    or #authentication.principal.role == 'ROLE_ADMIN'}"
+                    or #authorization.expression('hasRole(''ROLE_ADMIN'')')}"
            th:href="@{|/projects/${project.id}/tasks/new|}">
           <span class="icon">➕</span>
           Новая задача
@@ -69,11 +69,11 @@
         </a>
         <div class="d-flex gap-3">
           <a th:if="${project.owner.username == #authentication.name
-                      or #authentication.principal.role == 'ROLE_ADMIN'}"
+                      or #authorization.expression('hasRole(''ROLE_ADMIN'')')}"
              th:href="@{|/projects/${project.id}/edit|}"
              class="btn btn-outline-primary">Редактировать</a>
           <form th:if="${project.owner.username == #authentication.name
-                        or #authentication.principal.role == 'ROLE_ADMIN'}"
+                        or #authorization.expression('hasRole(''ROLE_ADMIN'')')}"
                 th:action="@{|/projects/${project.id}/delete|}"
                 method="post"
                 class="d-inline">
@@ -114,13 +114,8 @@
               <a th:href="@{|/projects/${project.id}/tasks/${t.id}|}"
                  class="btn btn-sm btn-outline-secondary"
                  title="Просмотр">Просмотр</a>
-              <a th:if="${project.owner.username == #authentication.name
-                            or #authentication.principal.role == 'ROLE_ADMIN'}"
-                 th:href="@{|/projects/${project.id}/tasks/${t.id}/edit|}"
-                 class="btn btn-sm btn-outline-primary"
-                 title="Редактировать">Редактировать</a>
               <form th:if="${project.owner.username == #authentication.name
-                               or #authentication.principal.role == 'ROLE_ADMIN'}"
+                               or #authorization.expression('hasRole(''ROLE_ADMIN'')')}"
                     th:action="@{|/projects/${project.id}/tasks/${t.id}/delete|}"
                     method="post"
                     class="d-inline">

--- a/demo/src/main/resources/templates/project/list.html
+++ b/demo/src/main/resources/templates/project/list.html
@@ -106,7 +106,7 @@
                                             </a>
 
                                             <!-- Кнопка-мусорка -->
-                                            <form th:if="${p.owner.username == #authentication.name or #authentication.principal.role == 'ROLE_ADMIN'}"
+                                            <form th:if="${p.owner.username == #authentication.name or #authorization.expression('hasRole(''ROLE_ADMIN'')')}"
                                                   th:action="@{|/projects/${p.id}/delete|}"
                                                   method="post"
                                                   class="m-0 p-0 border-0 d-inline"

--- a/demo/src/main/resources/templates/task/details.html
+++ b/demo/src/main/resources/templates/task/details.html
@@ -28,7 +28,7 @@
 
       <!-- Кнопки справа -->
       <div class="d-flex gap-2"
-           th:if="${project.owner.username == #authentication.name or #authentication.principal.role == 'ROLE_ADMIN'}">
+           th:if="${project.owner.username == #authentication.name or #authorization.expression('hasRole(''ROLE_ADMIN'')')}">
         <a th:href="@{|/projects/${project.id}/tasks/${task.id}/edit|}"
            class="btn btn-sm btn-outline-light"
            title="Редактировать">
@@ -65,6 +65,15 @@
           <td th:text="${task.assignedUser != null ? task.assignedUser.username : '—'}">123456</td>
         </tr>
         <tr>
+          <th>Участники</th>
+          <td>
+            <span th:if="${#lists.isEmpty(task.participants)}">—</span>
+            <span th:each="p,iter : ${task.participants}">
+              <span th:text="${p.username}"></span><span th:if="${!iter.last}">, </span>
+            </span>
+          </td>
+        </tr>
+        <tr>
           <th>Проект</th>
           <td>
             <a th:href="@{|/projects/${project.id}/view|}" th:text="${project.name}">Проект</a>
@@ -74,9 +83,12 @@
       </table>
     </div>
 
-    <div class="card-footer text-start">
+    <div class="card-footer d-flex justify-content-between">
       <a th:href="@{|/projects/${project.id}/view|}" class="btn btn-outline-secondary">
-        ← Назад к проекту
+        ← В проект
+      </a>
+      <a th:href="@{/tasks}" class="btn btn-outline-secondary">
+        Ко всем задачам
       </a>
     </div>
   </div>

--- a/demo/src/main/resources/templates/task/form.html
+++ b/demo/src/main/resources/templates/task/form.html
@@ -68,10 +68,22 @@
             </select>
           </div>
 
+          <!-- Участники задачи -->
+          <div class="mb-3" th:if="${#lists.size(candidates) > 1}">
+            <label for="participantIds" class="form-label">Участники</label>
+            <select id="participantIds" name="participantIds" multiple class="form-select">
+              <option th:each="u : ${candidates}"
+                      th:value="${u.id}"
+                      th:text="${u.username}"
+                      th:selected="${task.participants.contains(u)}">
+              </option>
+            </select>
+          </div>
+
           <!-- Кнопки -->
           <div class="d-flex justify-content-between">
             <button type="submit" class="btn btn-primary">Сохранить</button>
-            <a th:href="@{|/projects/${projectId}/view|}" class="btn btn-outline-secondary">Отмена</a>
+            <a href="#" onclick="history.back(); return false;" class="btn btn-outline-secondary">Отмена</a>
           </div>
         </form>
       </div>


### PR DESCRIPTION
## Summary
- allow selecting multiple users as task participants
- update TaskController to handle participantIds
- show participants in task details
- fix admin role checks for task/project buttons
- provide editing from task page and navigation options

## Testing
- `mvn -q -DskipTests package` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent)*

------
https://chatgpt.com/codex/tasks/task_e_684215645dc4832aa482081bb6547538