### PR TITLE
Implement custom JPQL query

### DIFF
--- a/demo/src/main/java/itis/semestrovka/demo/repository/TeamRepository.java
+++ b/demo/src/main/java/itis/semestrovka/demo/repository/TeamRepository.java
@@ -3,7 +3,18 @@ package itis.semestrovka.demo.repository;
 
 import itis.semestrovka.demo.model.entity.Team;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
 
 public interface TeamRepository extends JpaRepository<Team, Long> {
-    // можно при необходимости добавить свои методы @Query/Criteria
+
+    /**
+     * Загрузить команду вместе с участниками одним запросом.
+     * Пример JPQL-запроса, который демонстрирует использование
+     * собственных запросов помимо методов Spring Data.
+     */
+    @Query("SELECT t FROM Team t LEFT JOIN FETCH t.members WHERE t.id = :id")
+    Optional<Team> findByIdWithMembers(@Param("id") Long id);
 }

--- a/demo/src/main/java/itis/semestrovka/demo/service/impl/TeamServiceImpl.java
+++ b/demo/src/main/java/itis/semestrovka/demo/service/impl/TeamServiceImpl.java
@@ -23,7 +23,13 @@ public class TeamServiceImpl implements TeamService {
     /* ---------- базовые методы ---------- */
 
     @Override public List<Team> findAllTeams()   { return teamRepo.findAll(); }
-    @Override public Team findById(Long id)      { return teamRepo.findById(id).orElseThrow(); }
+
+    @Override
+    public Team findById(Long id) {
+        // Используем собственный JPQL-запрос для загрузки команды вместе с участниками
+        return teamRepo.findByIdWithMembers(id).orElseThrow();
+    }
+
     @Override public Team create(Team t)         { return teamRepo.save(t); }
     @Override public void deleteById(Long id)    { teamRepo.deleteById(id); }
 


### PR DESCRIPTION
## Summary
- add a JPQL query `findByIdWithMembers` in `TeamRepository`
- use the new query in `TeamServiceImpl.findById`

## Testing
- `./mvnw test -q` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68422c6fb6f4832a976ca06772111118