### PR TITLE
Add email and phone fields to registration

### DIFF
--- a/demo/src/main/java/itis/semestrovka/demo/model/dto/RegistrationForm.java
+++ b/demo/src/main/java/itis/semestrovka/demo/model/dto/RegistrationForm.java
@@ -1,7 +1,9 @@
 // src/main/java/itis/semestrovka/demo/model/dto/RegistrationForm.java
 package itis.semestrovka.demo.model.dto;
 
+import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 import lombok.Data;
 
@@ -14,4 +16,12 @@ public class RegistrationForm {
     @NotBlank
     @Size(min = 6)
     private String password;
+
+    @NotBlank
+    @Email
+    private String email;
+
+    @NotBlank
+    @Pattern(regexp = "\\+?\\d{10,15}", message = "Некорректный телефон")
+    private String phone;
 }

--- a/demo/src/main/java/itis/semestrovka/demo/model/entity/User.java
+++ b/demo/src/main/java/itis/semestrovka/demo/model/entity/User.java
@@ -22,6 +22,12 @@ public class User implements UserDetails {
     @Column(unique = true, nullable = false)
     private String username;
 
+    @Column(unique = true, nullable = false)
+    private String email;
+
+    @Column(unique = true, nullable = false)
+    private String phone;
+
     @Column(nullable = false)
     private String password;
 

--- a/demo/src/main/java/itis/semestrovka/demo/repository/UserRepository.java
+++ b/demo/src/main/java/itis/semestrovka/demo/repository/UserRepository.java
@@ -11,5 +11,9 @@ public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByUsername(String username);
     boolean existsByUsername(String username);
 
+    Optional<User> findByEmail(String email);
+
+    Optional<User> findByPhone(String phone);
+
     
 }

--- a/demo/src/main/java/itis/semestrovka/demo/service/impl/UserServiceImpl.java
+++ b/demo/src/main/java/itis/semestrovka/demo/service/impl/UserServiceImpl.java
@@ -31,9 +31,17 @@ public class UserServiceImpl implements UserService {
         users.findByUsername(form.getUsername())
                 .ifPresent(u -> { throw new IllegalArgumentException("Пользователь уже существует"); });
 
+        users.findByEmail(form.getEmail())
+                .ifPresent(u -> { throw new IllegalArgumentException("Email уже используется"); });
+
+        users.findByPhone(form.getPhone())
+                .ifPresent(u -> { throw new IllegalArgumentException("Телефон уже используется"); });
+
         User u = new User();
         u.setUsername(form.getUsername());
         u.setPassword(encoder.encode(form.getPassword()));
+        u.setEmail(form.getEmail());
+        u.setPhone(form.getPhone());
         u.setRole(Role.ROLE_USER);
         return users.save(u);
     }

--- a/demo/src/main/resources/templates/auth/register.html
+++ b/demo/src/main/resources/templates/auth/register.html
@@ -55,6 +55,34 @@
                 </div>
               </div>
 
+              <!-- Поле «Email» -->
+              <div class="form-group">
+                <label for="email">Email</label>
+                <input type="email"
+                       id="email"
+                       th:field="*{email}"
+                       placeholder="Введите email"
+                       required>
+                <div th:if="${#fields.hasErrors('email')}"
+                     th:errors="*{email}"
+                       class="text-danger">
+                </div>
+              </div>
+
+              <!-- Поле «Телефон» -->
+              <div class="form-group">
+                <label for="phone">Телефон</label>
+                <input type="text"
+                       id="phone"
+                       th:field="*{phone}"
+                       placeholder="Введите телефон"
+                       required>
+                <div th:if="${#fields.hasErrors('phone')}"
+                     th:errors="*{phone}"
+                       class="text-danger">
+                </div>
+              </div>
+
               <!-- Кнопка «Зарегистрироваться» -->
                 <button type="submit" class="btn btn-primary w-100">Зарегистрироваться</button>
             </form>


### PR DESCRIPTION
## Summary
- extend `RegistrationForm` with email and phone fields
- store email and phone in `User`
- check duplicates and save new fields in `UserServiceImpl`
- expose repository methods for email and phone
- update registration view to include email and phone inputs

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68422f9dc27c832a84d973c205e11b9e