### PR TITLE
Implement Google OAuth login

### DIFF
--- a/demo/src/main/java/itis/semestrovka/demo/config/SecurityConfig.java
+++ b/demo/src/main/java/itis/semestrovka/demo/config/SecurityConfig.java
@@ -38,7 +38,7 @@ public class SecurityConfig {
         http
                 .authenticationProvider(authProvider())
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/login", "/register", "/css/**", "/js/**").permitAll()
+                        .requestMatchers("/login", "/register", "/css/**", "/js/**", "/oauth2/**").permitAll()
                         .anyRequest().authenticated()
                 )
                 .formLogin(form -> form

--- a/demo/src/main/java/itis/semestrovka/demo/controller/oauth/GoogleOAuthController.java
+++ b/demo/src/main/java/itis/semestrovka/demo/controller/oauth/GoogleOAuthController.java
@@ -1,0 +1,39 @@
+package itis.semestrovka.demo.controller.oauth;
+
+import itis.semestrovka.demo.model.entity.User;
+import itis.semestrovka.demo.service.oauth.GoogleOAuthService;
+import jakarta.servlet.http.HttpSession;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@Controller
+@RequestMapping("/oauth2")
+public class GoogleOAuthController {
+
+    private final GoogleOAuthService googleOAuthService;
+
+    public GoogleOAuthController(GoogleOAuthService googleOAuthService) {
+        this.googleOAuthService = googleOAuthService;
+    }
+
+    @GetMapping("/authorize/google")
+    public String authorize(HttpSession session) {
+        String url = googleOAuthService.buildAuthorizationUrl(session);
+        return "redirect:" + url;
+    }
+
+    @GetMapping("/callback/google")
+    public String callback(@RequestParam String code,
+                           @RequestParam String state,
+                           HttpSession session) throws Exception {
+        User user = googleOAuthService.processCallback(code, state, session);
+        UsernamePasswordAuthenticationToken auth =
+                new UsernamePasswordAuthenticationToken(user, null, user.getAuthorities());
+        SecurityContextHolder.getContext().setAuthentication(auth);
+        return "redirect:/projects";
+    }
+}

--- a/demo/src/main/java/itis/semestrovka/demo/service/oauth/GoogleOAuthService.java
+++ b/demo/src/main/java/itis/semestrovka/demo/service/oauth/GoogleOAuthService.java
@@ -1,0 +1,148 @@
+package itis.semestrovka.demo.service.oauth;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import itis.semestrovka.demo.model.entity.Role;
+import itis.semestrovka.demo.model.entity.User;
+import itis.semestrovka.demo.repository.UserRepository;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URLEncoder;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+
+import jakarta.servlet.http.HttpSession;
+
+@Service
+@Transactional
+public class GoogleOAuthService {
+
+    @Value("${google.client-id}")
+    private String clientId;
+
+    @Value("${google.client-secret}")
+    private String clientSecret;
+
+    @Value("${google.redirect-uri}")
+    private String redirectUri;
+
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    public GoogleOAuthService(UserRepository userRepository, PasswordEncoder passwordEncoder) {
+        this.userRepository = userRepository;
+        this.passwordEncoder = passwordEncoder;
+    }
+
+    public String buildAuthorizationUrl(HttpSession session) {
+        String state = UUID.randomUUID().toString();
+        session.setAttribute("oauth2_state", state);
+        String base = "https://accounts.google.com/o/oauth2/v2/auth";
+        String url = base + "?client_id=" + encode(clientId)
+                + "&redirect_uri=" + encode(redirectUri)
+                + "&response_type=code&scope=" + encode("openid email profile")
+                + "&state=" + encode(state);
+        return url;
+    }
+
+    public User processCallback(String code, String state, HttpSession session) throws IOException, InterruptedException {
+        String savedState = (String) session.getAttribute("oauth2_state");
+        session.removeAttribute("oauth2_state");
+        if (savedState == null || !savedState.equals(state)) {
+            throw new IllegalStateException("Invalid state");
+        }
+
+        String token = fetchAccessToken(code);
+        GoogleUserInfo info = fetchUserInfo(token);
+
+        Optional<User> existing = userRepository.findByEmail(info.email());
+        User user = existing.orElseGet(() -> registerUser(info));
+        return user;
+    }
+
+    private String fetchAccessToken(String code) throws IOException, InterruptedException {
+        HttpClient client = HttpClient.newHttpClient();
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(URI.create("https://oauth2.googleapis.com/token"))
+                .header("Content-Type", "application/x-www-form-urlencoded")
+                .POST(ofFormData(Map.of(
+                        "client_id", clientId,
+                        "client_secret", clientSecret,
+                        "code", code,
+                        "redirect_uri", redirectUri,
+                        "grant_type", "authorization_code"
+                )))
+                .build();
+        HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+        if (response.statusCode() != 200) {
+            throw new IllegalStateException("Failed to obtain token");
+        }
+        JsonNode node = mapper.readTree(response.body());
+        return node.get("access_token").asText();
+    }
+
+    private GoogleUserInfo fetchUserInfo(String accessToken) throws IOException, InterruptedException {
+        HttpClient client = HttpClient.newHttpClient();
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(URI.create("https://www.googleapis.com/oauth2/v2/userinfo"))
+                .header("Authorization", "Bearer " + accessToken)
+                .build();
+        HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+        if (response.statusCode() != 200) {
+            throw new IllegalStateException("Failed to obtain user info");
+        }
+        JsonNode node = mapper.readTree(response.body());
+        return new GoogleUserInfo(
+                node.get("id").asText(),
+                node.get("email").asText(),
+                node.has("name") ? node.get("name").asText() : node.get("email").asText()
+        );
+    }
+
+    private User registerUser(GoogleUserInfo info) {
+        String baseUsername = info.name().replaceAll("\\s+", "").toLowerCase();
+        if (baseUsername.isEmpty()) {
+            baseUsername = info.email().split("@")[0];
+        }
+        String username = baseUsername;
+        int i = 1;
+        while (userRepository.existsByUsername(username)) {
+            username = baseUsername + i++;
+        }
+        User u = new User();
+        u.setUsername(username);
+        u.setEmail(info.email());
+        u.setPhone("google-" + info.id());
+        u.setPassword(passwordEncoder.encode(UUID.randomUUID().toString()));
+        u.setRole(Role.ROLE_USER);
+        return userRepository.save(u);
+    }
+
+    private static String encode(String value) {
+        return URLEncoder.encode(value, StandardCharsets.UTF_8);
+    }
+
+    private static HttpRequest.BodyPublisher ofFormData(Map<String, String> data) {
+        StringBuilder builder = new StringBuilder();
+        for (Map.Entry<String, String> entry : data.entrySet()) {
+            if (builder.length() > 0) {
+                builder.append("&");
+            }
+            builder.append(encode(entry.getKey())).append("=").append(encode(entry.getValue()));
+        }
+        return HttpRequest.BodyPublishers.ofString(builder.toString());
+    }
+
+    private record GoogleUserInfo(String id, String email, String name) {}
+}

--- a/demo/src/main/resources/application.yaml
+++ b/demo/src/main/resources/application.yaml
@@ -18,3 +18,8 @@ spring:
     properties:
       hibernate:
         format_sql: true
+
+google:
+  client-id: ${GOOGLE_CLIENT_ID:}
+  client-secret: ${GOOGLE_CLIENT_SECRET:}
+  redirect-uri: ${GOOGLE_REDIRECT_URI:http://localhost:8080/oauth2/callback/google}

--- a/demo/src/main/resources/templates/auth/login.html
+++ b/demo/src/main/resources/templates/auth/login.html
@@ -39,6 +39,10 @@
             <button type="submit" class="btn btn-primary w-100">Войти</button>
           </form>
 
+          <div class="mt-3">
+            <a th:href="@{/oauth2/authorize/google}" class="btn btn-danger w-100">Войти через Google</a>
+          </div>
+
           <div class="text-center mt-2">
             Нет аккаунта?
             <a th:href="@{/register}">Зарегистрироваться</a>


### PR DESCRIPTION
## Summary
- allow access to `/oauth2/**` URLs
- add Google OAuth configuration
- create `GoogleOAuthService` to handle manual OAuth flow
- add controller for Google OAuth callbacks
- show a 'Login with Google' button

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_684234bce938832a896830f2a6a45845