### PR TITLE
Add phone SMS step after Google login

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ This project is a simple Spring Boot app used for managing teams and projects. I
    - `GOOGLE_CLIENT_ID` – Client ID from your Google Cloud OAuth consent screen.
    - `GOOGLE_CLIENT_SECRET` – Client secret for the same OAuth client.
    - `GOOGLE_REDIRECT_URI` (optional) – Defaults to `http://localhost:8080/oauth2/callback/google` and must match the allowed redirect URI in Google settings.
+   - `SMS_API_ID` – API key for sms.ru or another SMS provider.
+   - `SMS_API_URL` (optional) – Endpoint for sending SMS, defaults to `https://sms.ru/sms/send`.
 3. Build and run using Maven:
 
 ```bash

--- a/demo/src/main/java/itis/semestrovka/demo/controller/oauth/GoogleOAuthController.java
+++ b/demo/src/main/java/itis/semestrovka/demo/controller/oauth/GoogleOAuthController.java
@@ -34,6 +34,9 @@ public class GoogleOAuthController {
         UsernamePasswordAuthenticationToken auth =
                 new UsernamePasswordAuthenticationToken(user, null, user.getAuthorities());
         SecurityContextHolder.getContext().setAuthentication(auth);
+        if (user.getPhone() != null && user.getPhone().startsWith("google-")) {
+            return "redirect:/oauth2/phone";
+        }
         return "redirect:/projects";
     }
 }

--- a/demo/src/main/java/itis/semestrovka/demo/controller/oauth/PhoneController.java
+++ b/demo/src/main/java/itis/semestrovka/demo/controller/oauth/PhoneController.java
@@ -1,0 +1,46 @@
+package itis.semestrovka.demo.controller.oauth;
+
+import itis.semestrovka.demo.model.entity.User;
+import itis.semestrovka.demo.service.UserService;
+import itis.semestrovka.demo.service.sms.SmsService;
+import jakarta.servlet.http.HttpSession;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@Controller
+@RequestMapping("/oauth2/phone")
+public class PhoneController {
+
+    private final UserService userService;
+    private final SmsService smsService;
+
+    public PhoneController(UserService userService, SmsService smsService) {
+        this.userService = userService;
+        this.smsService = smsService;
+    }
+
+    @GetMapping
+    public String phoneForm(Model model) {
+        model.addAttribute("title", "Введите телефон");
+        return "oauth/phone";
+    }
+
+    @PostMapping
+    public String submitPhone(@RequestParam String phone,
+                              HttpSession session,
+                              @AuthenticationPrincipal User user) {
+        userService.updatePhone(user, phone);
+        String password = (String) session.getAttribute("oauth_password");
+        session.removeAttribute("oauth_password");
+        if (password != null) {
+            String msg = "Ваш логин: " + user.getUsername() + "\nПароль: " + password;
+            smsService.sendSms(phone, msg);
+        }
+        return "redirect:/projects";
+    }
+}

--- a/demo/src/main/java/itis/semestrovka/demo/service/UserService.java
+++ b/demo/src/main/java/itis/semestrovka/demo/service/UserService.java
@@ -17,4 +17,7 @@ public interface UserService extends UserDetailsService {
 
     /** Найти пользователя по id (или бросить исключение) */
     User findById(Long id);
+
+    /** Обновить номер телефона пользователя */
+    void updatePhone(User user, String phone);
 }

--- a/demo/src/main/java/itis/semestrovka/demo/service/impl/SmsServiceImpl.java
+++ b/demo/src/main/java/itis/semestrovka/demo/service/impl/SmsServiceImpl.java
@@ -1,0 +1,45 @@
+package itis.semestrovka.demo.service.impl;
+
+import itis.semestrovka.demo.service.sms.SmsService;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.net.URI;
+import java.net.URLEncoder;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+
+@Service
+public class SmsServiceImpl implements SmsService {
+
+    @Value("${sms.api-url}")
+    private String apiUrl;
+
+    @Value("${sms.api-id}")
+    private String apiId;
+
+    private final HttpClient client = HttpClient.newHttpClient();
+
+    @Override
+    public void sendSms(String phone, String message) {
+        try {
+            String url = apiUrl + "?api_id=" + encode(apiId)
+                    + "&to=" + encode(phone)
+                    + "&msg=" + encode(message)
+                    + "&json=1";
+            HttpRequest request = HttpRequest.newBuilder()
+                    .uri(URI.create(url))
+                    .GET()
+                    .build();
+            client.send(request, HttpResponse.BodyHandlers.ofString());
+        } catch (Exception e) {
+            throw new IllegalStateException("Failed to send SMS", e);
+        }
+    }
+
+    private static String encode(String s) {
+        return URLEncoder.encode(s, StandardCharsets.UTF_8);
+    }
+}

--- a/demo/src/main/java/itis/semestrovka/demo/service/impl/UserServiceImpl.java
+++ b/demo/src/main/java/itis/semestrovka/demo/service/impl/UserServiceImpl.java
@@ -63,4 +63,15 @@ public class UserServiceImpl implements UserService {
                 .orElseThrow(() ->
                         new UsernameNotFoundException("Пользователь " + username + " не найден"));
     }
+
+    @Override
+    public void updatePhone(User user, String phone) {
+        users.findByPhone(phone).ifPresent(u -> {
+            if (!u.getId().equals(user.getId())) {
+                throw new IllegalArgumentException("Телефон уже используется");
+            }
+        });
+        user.setPhone(phone);
+        users.save(user);
+    }
 }

--- a/demo/src/main/java/itis/semestrovka/demo/service/oauth/GoogleOAuthService.java
+++ b/demo/src/main/java/itis/semestrovka/demo/service/oauth/GoogleOAuthService.java
@@ -67,7 +67,7 @@ public class GoogleOAuthService {
         GoogleUserInfo info = fetchUserInfo(token);
 
         Optional<User> existing = userRepository.findByEmail(info.email());
-        User user = existing.orElseGet(() -> registerUser(info));
+        User user = existing.orElseGet(() -> registerUser(info, session));
         return user;
     }
 
@@ -110,7 +110,7 @@ public class GoogleOAuthService {
         );
     }
 
-    private User registerUser(GoogleUserInfo info) {
+    private User registerUser(GoogleUserInfo info, HttpSession session) {
         String baseUsername = info.name().replaceAll("\\s+", "").toLowerCase();
         if (baseUsername.isEmpty()) {
             baseUsername = info.email().split("@")[0];
@@ -124,7 +124,9 @@ public class GoogleOAuthService {
         u.setUsername(username);
         u.setEmail(info.email());
         u.setPhone("google-" + info.id());
-        u.setPassword(passwordEncoder.encode(UUID.randomUUID().toString()));
+        String rawPassword = UUID.randomUUID().toString();
+        u.setPassword(passwordEncoder.encode(rawPassword));
+        session.setAttribute("oauth_password", rawPassword);
         u.setRole(Role.ROLE_USER);
         return userRepository.save(u);
     }

--- a/demo/src/main/java/itis/semestrovka/demo/service/sms/SmsService.java
+++ b/demo/src/main/java/itis/semestrovka/demo/service/sms/SmsService.java
@@ -1,0 +1,5 @@
+package itis.semestrovka.demo.service.sms;
+
+public interface SmsService {
+    void sendSms(String phone, String message);
+}

--- a/demo/src/main/resources/application.yaml
+++ b/demo/src/main/resources/application.yaml
@@ -23,3 +23,7 @@ google:
   client-id: ${GOOGLE_CLIENT_ID:}
   client-secret: ${GOOGLE_CLIENT_SECRET:}
   redirect-uri: ${GOOGLE_REDIRECT_URI:http://localhost:8080/oauth2/callback/google}
+
+sms:
+  api-url: ${SMS_API_URL:https://sms.ru/sms/send}
+  api-id: ${SMS_API_ID:}

--- a/demo/src/main/resources/templates/oauth/phone.html
+++ b/demo/src/main/resources/templates/oauth/phone.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="ru"
+      xmlns:th="http://www.thymeleaf.org"
+      xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
+      layout:decorate="~{layout}">
+<head>
+  <title layout:fragment="title">Телефон</title>
+</head>
+<body>
+<div layout:fragment="content">
+  <div class="row justify-content-center mt-4 mb-4">
+    <div class="col-12 col-sm-8 col-md-6 col-lg-4">
+      <div class="card">
+        <div class="card-header">
+          <h3 class="mb-0">Укажите номер телефона</h3>
+        </div>
+        <div class="card-body">
+          <form th:action="@{/oauth2/phone}" method="post">
+            <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" />
+            <div class="form-group mb-3">
+              <label for="phone">Телефон</label>
+              <input type="tel" class="form-control" id="phone" name="phone" placeholder="+7XXXXXXXXXX" required>
+            </div>
+            <button type="submit" class="btn btn-primary w-100">Отправить</button>
+          </form>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add SMS provider configuration
- implement a simple `SmsService` using `HttpClient`
- update OAuth flow to register users with generated password and ask for phone
- provide a form and controller to collect phone number and send SMS
- document new environment variables

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68423da84498832aab8bf0773f40169a