### PR TITLE
Show Telegram prompt after Google login

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ cd demo
 ```
 
 After launch, open `http://localhost:8080/login` and use the "Войти через Google" button to authenticate via Google.
+After a successful Google login you will be redirected to the projects page. If you haven't linked Telegram yet you will see a reminder asking to open the bot.
 
-To link your Telegram account, send `/start` to your bot and make it call
-`/telegram/register?chatId=<yourChatId>` while you are logged in.
+To link your Telegram account, send `/start` to your bot and make it call `/telegram/register?chatId=<yourChatId>` while you are logged in. Once linked, the bot will send you your generated login and password.
 

--- a/demo/src/main/java/itis/semestrovka/demo/controller/ProjectController.java
+++ b/demo/src/main/java/itis/semestrovka/demo/controller/ProjectController.java
@@ -40,6 +40,7 @@ public class ProjectController {
             @RequestParam(value = "type", required = false, defaultValue = "all") String type,
             @RequestParam(value = "sortField", required = false, defaultValue = "name") String sortField,
             @RequestParam(value = "sortDir", required = false, defaultValue = "asc") String sortDir,
+            @RequestParam(value = "telegramPrompt", required = false) String telegramPrompt,
             Model model,
             @AuthenticationPrincipal User currentUser
     ) {
@@ -115,6 +116,7 @@ public class ProjectController {
         // Для удобства переключения направления сортировки (при клике на заголовок)
         String reverseDir = sortDir.equalsIgnoreCase("asc") ? "desc" : "asc";
         model.addAttribute("reverseDir", reverseDir);
+        model.addAttribute("showTelegramPrompt", telegramPrompt != null);
 
         return "project/list";
     }

--- a/demo/src/main/java/itis/semestrovka/demo/controller/oauth/GoogleOAuthController.java
+++ b/demo/src/main/java/itis/semestrovka/demo/controller/oauth/GoogleOAuthController.java
@@ -34,6 +34,12 @@ public class GoogleOAuthController {
         UsernamePasswordAuthenticationToken auth =
                 new UsernamePasswordAuthenticationToken(user, null, user.getAuthorities());
         SecurityContextHolder.getContext().setAuthentication(auth);
-        return "redirect:/projects";
+
+        // Если пользователь еще не привязал Telegram, покажем напоминание
+        String redirect = "/projects";
+        if (user.getTelegramChatId() == null) {
+            redirect += "?telegramPrompt";
+        }
+        return "redirect:" + redirect;
     }
 }

--- a/demo/src/main/resources/templates/project/list.html
+++ b/demo/src/main/resources/templates/project/list.html
@@ -15,6 +15,11 @@
 <div layout:fragment="content">
     <div class="container mt-4">
 
+        <div th:if="${showTelegramPrompt}" class="alert alert-info text-center mb-4">
+            Для получения логина и пароля перейдите в
+            <a href="https://t.me/your_bot" target="_blank">Telegram-бот</a>.
+        </div>
+
         <!-- ===== ФИЛЬТР ===== -->
         <div class="row mb-3">
             <div class="col-auto">


### PR DESCRIPTION
## Summary
- prompt user to link Telegram after Google login
- pass telegramPrompt query and display message on projects
- document Telegram reminder in README

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68424fec9ad4832a939da8d26a1cd656