### PR TITLE
Redirect Google OAuth users to Telegram bot

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ This project is a simple Spring Boot app used for managing teams and projects. I
    - `GOOGLE_CLIENT_SECRET` – Client secret for the same OAuth client.
    - `GOOGLE_REDIRECT_URI` (optional) – Defaults to `http://localhost:8080/oauth2/callback/google` and must match the allowed redirect URI in Google settings.
    - `TELEGRAM_BOT_TOKEN` – Bot token obtained from @BotFather.
+   - `TELEGRAM_BOT_LINK` – Public link to your bot (e.g. `https://t.me/your_bot`).
 
 3. Build and run using Maven:
 
@@ -19,7 +20,7 @@ cd demo
 ```
 
 After launch, open `http://localhost:8080/login` and use the "Войти через Google" button to authenticate via Google.
-After a successful Google login you will be redirected to the projects page. If you haven't linked Telegram yet you will see a reminder asking to open the bot.
+After a successful Google login you will be redirected to your Telegram bot so it can deliver your generated login and password.
 
-To link your Telegram account, send `/start` to your bot and make it call `/telegram/register?chatId=<yourChatId>` while you are logged in. Once linked, the bot will send you your generated login and password.
+If needed, the bot can link your chat by calling `/telegram/register?chatId=<yourChatId>` while you remain logged in. After registration the bot will send you the credentials stored during the Google sign in.
 

--- a/demo/src/main/java/itis/semestrovka/demo/controller/ProjectController.java
+++ b/demo/src/main/java/itis/semestrovka/demo/controller/ProjectController.java
@@ -6,6 +6,7 @@ import itis.semestrovka.demo.model.entity.Task;
 import itis.semestrovka.demo.model.entity.User;
 import itis.semestrovka.demo.model.entity.Role;
 import itis.semestrovka.demo.service.ProjectService;
+import org.springframework.beans.factory.annotation.Value;
 import jakarta.validation.Valid;
 import org.springframework.data.domain.Sort;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -22,6 +23,8 @@ import java.util.List;
 public class ProjectController {
 
     private final ProjectService projectService;
+    @Value("${telegram.bot-link:https://t.me/your_bot}")
+    private String botLink;
 
     public ProjectController(ProjectService projectService) {
         this.projectService = projectService;
@@ -117,6 +120,7 @@ public class ProjectController {
         String reverseDir = sortDir.equalsIgnoreCase("asc") ? "desc" : "asc";
         model.addAttribute("reverseDir", reverseDir);
         model.addAttribute("showTelegramPrompt", telegramPrompt != null);
+        model.addAttribute("botLink", botLink);
 
         return "project/list";
     }

--- a/demo/src/main/java/itis/semestrovka/demo/controller/TelegramController.java
+++ b/demo/src/main/java/itis/semestrovka/demo/controller/TelegramController.java
@@ -2,6 +2,8 @@ package itis.semestrovka.demo.controller;
 
 import itis.semestrovka.demo.model.entity.User;
 import itis.semestrovka.demo.service.UserService;
+import itis.semestrovka.demo.service.telegram.TelegramService;
+import jakarta.servlet.http.HttpSession;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -13,15 +15,28 @@ import org.springframework.web.bind.annotation.RestController;
 public class TelegramController {
 
     private final UserService userService;
+    private final TelegramService telegramService;
 
-    public TelegramController(UserService userService) {
+    public TelegramController(UserService userService, TelegramService telegramService) {
         this.userService = userService;
+        this.telegramService = telegramService;
     }
 
     @GetMapping("/register")
     public String register(@RequestParam String chatId,
-                           @AuthenticationPrincipal User user) {
+                           @AuthenticationPrincipal User user,
+                           HttpSession session) {
         userService.updateTelegramChatId(user, chatId);
+
+        String username = (String) session.getAttribute("pendingUsername");
+        String password = (String) session.getAttribute("pendingPassword");
+        if (username != null && password != null) {
+            String msg = "Ваш логин: " + username + "\nПароль: " + password;
+            telegramService.sendMessage(chatId, msg);
+            session.removeAttribute("pendingUsername");
+            session.removeAttribute("pendingPassword");
+        }
+
         return "ok";
     }
 }

--- a/demo/src/main/java/itis/semestrovka/demo/controller/oauth/GoogleOAuthController.java
+++ b/demo/src/main/java/itis/semestrovka/demo/controller/oauth/GoogleOAuthController.java
@@ -3,6 +3,7 @@ package itis.semestrovka.demo.controller.oauth;
 import itis.semestrovka.demo.model.entity.User;
 import itis.semestrovka.demo.service.oauth.GoogleOAuthService;
 import jakarta.servlet.http.HttpSession;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Controller;
@@ -15,6 +16,8 @@ import org.springframework.web.bind.annotation.RequestParam;
 public class GoogleOAuthController {
 
     private final GoogleOAuthService googleOAuthService;
+    @Value("${telegram.bot-link:https://t.me/your_bot}")
+    private String botLink;
 
     public GoogleOAuthController(GoogleOAuthService googleOAuthService) {
         this.googleOAuthService = googleOAuthService;
@@ -35,11 +38,9 @@ public class GoogleOAuthController {
                 new UsernamePasswordAuthenticationToken(user, null, user.getAuthorities());
         SecurityContextHolder.getContext().setAuthentication(auth);
 
-        // Если пользователь еще не привязал Telegram, покажем напоминание
-        String redirect = "/projects";
         if (user.getTelegramChatId() == null) {
-            redirect += "?telegramPrompt";
+            return "redirect:" + botLink;
         }
-        return "redirect:" + redirect;
+        return "redirect:/projects";
     }
 }

--- a/demo/src/main/java/itis/semestrovka/demo/service/oauth/GoogleOAuthService.java
+++ b/demo/src/main/java/itis/semestrovka/demo/service/oauth/GoogleOAuthService.java
@@ -134,6 +134,11 @@ public class GoogleOAuthService {
         u.setRole(Role.ROLE_USER);
         u = userRepository.save(u);
 
+        // remember credentials in the HTTP session so they can be sent
+        // after the user links Telegram
+        session.setAttribute("pendingUsername", username);
+        session.setAttribute("pendingPassword", rawPassword);
+
 
         String message = "Ваш логин: " + username + "\nПароль: " + rawPassword;
         if (u.getTelegramChatId() != null) {

--- a/demo/src/main/resources/application.yaml
+++ b/demo/src/main/resources/application.yaml
@@ -26,4 +26,5 @@ google:
 
 telegram:
   bot-token: ${TELEGRAM_BOT_TOKEN:7995355623:AAFZ1JZBOKR66n2IyHAIlVESM7ye_5Dqgcs}
+  bot-link: ${TELEGRAM_BOT_LINK:https://t.me/your_bot}
 

--- a/demo/src/main/resources/templates/project/list.html
+++ b/demo/src/main/resources/templates/project/list.html
@@ -17,7 +17,7 @@
 
         <div th:if="${showTelegramPrompt}" class="alert alert-info text-center mb-4">
             Для получения логина и пароля перейдите в
-            <a href="https://t.me/your_bot" target="_blank">Telegram-бот</a>.
+            <a th:href="${botLink}" target="_blank">Telegram-бот</a>.
         </div>
 
         <!-- ===== ФИЛЬТР ===== -->


### PR DESCRIPTION
## Summary
- store generated credentials in session when creating a new Google user
- send credentials on `/telegram/register`
- redirect OAuth callback to Telegram bot if chat not linked
- expose bot link in configuration and templates
- document new `TELEGRAM_BOT_LINK` env var

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68429fbd95a8832abc90fd1747933f82