### PR TITLE
Update Google OAuth flow to capture phone

### DIFF
--- a/demo/src/main/java/itis/semestrovka/demo/controller/TelegramController.java
+++ b/demo/src/main/java/itis/semestrovka/demo/controller/TelegramController.java
@@ -10,6 +10,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import jakarta.servlet.http.HttpSession;
 
 @RestController
 @RequestMapping("/telegram")
@@ -45,15 +46,12 @@ public class TelegramController {
     }
 
     /**
-     * Endpoint used by the Telegram bot to finish Google registration.
-     * It expects a token generated during OAuth login, the phone number
-     * entered by the user in Telegram and the chat id to reply to.
+     * Endpoint used by the Telegram bot after the user sends their phone number.
+     * The bot provides the phone and chat id so the service can deliver the credentials.
      */
     @GetMapping("/complete")
-    public String complete(@RequestParam String token,
-                           @RequestParam String phone,
-                           @RequestParam String chatId) {
-        googleOAuthService.completePhoneRegistration(token, phone, chatId);
+    public String complete(@RequestParam String phone, @RequestParam String chatId) {
+        googleOAuthService.completePhoneRegistration(phone, chatId);
         return "ok";
     }
 }

--- a/demo/src/main/resources/templates/auth/phone.html
+++ b/demo/src/main/resources/templates/auth/phone.html
@@ -23,7 +23,7 @@
                         <button type="submit" class="btn btn-primary w-100">Отправить в Telegram</button>
                     </form>
                     <div class="text-center mt-2">
-                        После отправки номера проверьте сообщения от бота в Telegram.
+                        После отправки номера отправьте его боту в Telegram, чтобы получить логин и пароль.
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
## Summary
- show a phone input page after logging in through Google
- store pending credentials by phone and deliver them when the bot calls back
- update Telegram controller to complete registration using phone
- revert profile view and remove Telegram link

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6842ac5e97d8832aaf79b31808b7ea5b