### PR TITLE
Add Slack webhook notifications

### DIFF
--- a/demo/src/main/java/itis/semestrovka/demo/config/AppConfig.java
+++ b/demo/src/main/java/itis/semestrovka/demo/config/AppConfig.java
@@ -1,0 +1,15 @@
+package itis.semestrovka.demo.config;
+
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class AppConfig {
+
+    @Bean
+    public RestTemplate restTemplate(RestTemplateBuilder builder) {
+        return builder.build();
+    }
+}

--- a/demo/src/main/java/itis/semestrovka/demo/controller/TaskController.java
+++ b/demo/src/main/java/itis/semestrovka/demo/controller/TaskController.java
@@ -9,6 +9,7 @@ import itis.semestrovka.demo.service.ProjectService;
 import itis.semestrovka.demo.service.TaskService;
 import itis.semestrovka.demo.service.UserService;
 import itis.semestrovka.demo.service.CommentService;
+import itis.semestrovka.demo.service.SlackService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -33,6 +34,7 @@ public class TaskController {
     private final ProjectService projectService;
     private final UserService    userService;   // ← добавили
     private final CommentService commentService;
+    private final SlackService slackService;
 
     /* ----------  ФОРМА СОЗДАНИЯ  ---------- */
     @GetMapping("/new")
@@ -109,6 +111,8 @@ public class TaskController {
         task.setParticipants(participants);
 
         taskService.save(task);
+        slackService.sendTaskCreatedNotification(
+                project.getName(), task.getTitle(), currentUser.getUsername());
         return "redirect:/projects/" + projectId + "/view";
     }
 

--- a/demo/src/main/java/itis/semestrovka/demo/service/SlackService.java
+++ b/demo/src/main/java/itis/semestrovka/demo/service/SlackService.java
@@ -1,0 +1,5 @@
+package itis.semestrovka.demo.service;
+
+public interface SlackService {
+    void sendTaskCreatedNotification(String projectName, String taskTitle, String authorUsername);
+}

--- a/demo/src/main/java/itis/semestrovka/demo/service/impl/SlackServiceImpl.java
+++ b/demo/src/main/java/itis/semestrovka/demo/service/impl/SlackServiceImpl.java
@@ -1,0 +1,45 @@
+package itis.semestrovka.demo.service.impl;
+
+import itis.semestrovka.demo.service.SlackService;
+import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+public class SlackServiceImpl implements SlackService {
+
+    private static final Logger log = LoggerFactory.getLogger(SlackServiceImpl.class);
+
+    private final RestTemplate restTemplate;
+
+    @Value("${slack.webhook-url}")
+    private String webhookUrl;
+
+    @Override
+    public void sendTaskCreatedNotification(String projectName, String taskTitle, String authorUsername) {
+        if (webhookUrl == null || webhookUrl.isBlank()) {
+            log.warn("Slack webhook URL is not configured");
+            return;
+        }
+        String text = String.format("Новая задача \"%s\" в проекте \"%s\" (автор: %s)",
+                taskTitle, projectName, authorUsername);
+        Map<String, String> payload = Map.of("text", text);
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        HttpEntity<Map<String, String>> entity = new HttpEntity<>(payload, headers);
+        try {
+            restTemplate.postForEntity(webhookUrl, entity, String.class);
+        } catch (Exception e) {
+            log.error("Failed to send Slack notification", e);
+        }
+    }
+}

--- a/demo/src/main/resources/application.yaml
+++ b/demo/src/main/resources/application.yaml
@@ -23,4 +23,7 @@ google:
   client-secret: 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
   redirect-uri: http://localhost:8080/oauth2/callback/google
 
+slack:
+  webhook-url: ${SLACK_WEBHOOK_URL:}
+
 


### PR DESCRIPTION
## Summary
- configure Slack webhook URL in `application.yaml`
- add `SlackService` with RestTemplate implementation
- register RestTemplate bean
- send Slack notification when tasks are created

## Testing
- `mvnw test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6842bc3959fc832aa5567c0eea6b8812