### PR TITLE
Auto-login after Google OAuth

### DIFF
--- a/demo/src/main/java/itis/semestrovka/demo/controller/oauth/GoogleOAuthController.java
+++ b/demo/src/main/java/itis/semestrovka/demo/controller/oauth/GoogleOAuthController.java
@@ -3,6 +3,9 @@ package itis.semestrovka.demo.controller.oauth;
 import itis.semestrovka.demo.model.entity.User;
 import itis.semestrovka.demo.service.oauth.GoogleOAuthService;
 import jakarta.servlet.http.HttpSession;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.context.HttpSessionSecurityContextRepository;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -31,11 +34,21 @@ public class GoogleOAuthController {
                            @RequestParam String state,
                            HttpSession session) throws Exception {
         GoogleOAuthService.OAuthResult result = googleOAuthService.processCallback(code, state, session);
+
         session.setAttribute("pendingUsername", result.user().getUsername());
-        if (session.getAttribute("pendingPassword") == null) {
+        if (session.getAttribute("pendingPassword") != null) {
             session.removeAttribute("pendingPassword");
         }
-        return "redirect:/login";
+
+        UsernamePasswordAuthenticationToken auth =
+                UsernamePasswordAuthenticationToken.authenticated(
+                        result.user(), result.user().getPassword(), result.user().getAuthorities());
+        var context = SecurityContextHolder.createEmptyContext();
+        context.setAuthentication(auth);
+        SecurityContextHolder.setContext(context);
+        session.setAttribute(HttpSessionSecurityContextRepository.SPRING_SECURITY_CONTEXT_KEY, context);
+
+        return "redirect:/projects";
 
     }
 }


### PR DESCRIPTION
## Summary
- authenticate users immediately in Google OAuth callback
- redirect directly to `/projects`

## Testing
- `mvn -q -DskipTests package` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842c4d0ff90832abe614320480df01f