### PR TITLE
Add password setup for Google logins

### DIFF
--- a/demo/src/main/java/itis/semestrovka/demo/controller/PasswordController.java
+++ b/demo/src/main/java/itis/semestrovka/demo/controller/PasswordController.java
@@ -1,0 +1,55 @@
+package itis.semestrovka.demo.controller;
+
+import itis.semestrovka.demo.model.dto.PasswordForm;
+import itis.semestrovka.demo.model.entity.User;
+import itis.semestrovka.demo.service.UserService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@Controller
+@RequestMapping("/set-password")
+@RequiredArgsConstructor
+public class PasswordController {
+
+    private final UserService userService;
+
+    @GetMapping
+    public String form(@AuthenticationPrincipal User currentUser, Model model) {
+        model.addAttribute("title", "Установить пароль");
+        if (!currentUser.getPhone().startsWith("google-")) {
+            model.addAttribute("alreadySet", true);
+            return "auth/set_password";
+        }
+        if (currentUser.isPasswordSet()) {
+            model.addAttribute("alreadySet", true);
+            return "auth/set_password";
+        }
+        model.addAttribute("form", new PasswordForm());
+        return "auth/set_password";
+    }
+
+    @PostMapping
+    public String save(@Valid @ModelAttribute("form") PasswordForm form,
+                       BindingResult br,
+                       @AuthenticationPrincipal User currentUser,
+                       Model model) {
+        model.addAttribute("title", "Установить пароль");
+        if (!currentUser.getPhone().startsWith("google-") || currentUser.isPasswordSet()) {
+            model.addAttribute("alreadySet", true);
+            return "auth/set_password";
+        }
+        if (br.hasErrors()) {
+            return "auth/set_password";
+        }
+        userService.updatePassword(currentUser, form.getPassword());
+        return "redirect:/projects";
+    }
+}

--- a/demo/src/main/java/itis/semestrovka/demo/model/dto/PasswordForm.java
+++ b/demo/src/main/java/itis/semestrovka/demo/model/dto/PasswordForm.java
@@ -1,0 +1,12 @@
+package itis.semestrovka.demo.model.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Data;
+
+@Data
+public class PasswordForm {
+    @NotBlank(message = "Пароль обязателен")
+    @Size(min = 8, message = "Пароль должен быть не менее 8 символов")
+    private String password;
+}

--- a/demo/src/main/java/itis/semestrovka/demo/model/entity/User.java
+++ b/demo/src/main/java/itis/semestrovka/demo/model/entity/User.java
@@ -33,6 +33,9 @@ public class User implements UserDetails {
     private String password;
 
     @Column(nullable = false)
+    private boolean passwordSet = false;
+
+    @Column(nullable = false)
     private boolean enabled = true;
 
     @Enumerated(EnumType.STRING)

--- a/demo/src/main/java/itis/semestrovka/demo/service/UserService.java
+++ b/demo/src/main/java/itis/semestrovka/demo/service/UserService.java
@@ -21,4 +21,7 @@ public interface UserService extends UserDetailsService {
     /** Обновить номер телефона пользователя */
     void updatePhone(User user, String phone);
 
+    /** Установить или изменить пароль пользователя */
+    void updatePassword(User user, String password);
+
 }

--- a/demo/src/main/java/itis/semestrovka/demo/service/impl/UserServiceImpl.java
+++ b/demo/src/main/java/itis/semestrovka/demo/service/impl/UserServiceImpl.java
@@ -40,6 +40,7 @@ public class UserServiceImpl implements UserService {
         User u = new User();
         u.setUsername(form.getUsername());
         u.setPassword(encoder.encode(form.getPassword()));
+        u.setPasswordSet(true);
         u.setEmail(form.getEmail());
         u.setPhone(form.getPhone());
         u.setRole(Role.ROLE_USER);
@@ -72,6 +73,13 @@ public class UserServiceImpl implements UserService {
             }
         });
         user.setPhone(phone);
+        users.save(user);
+    }
+
+    @Override
+    public void updatePassword(User user, String password) {
+        user.setPassword(encoder.encode(password));
+        user.setPasswordSet(true);
         users.save(user);
     }
 

--- a/demo/src/main/java/itis/semestrovka/demo/service/oauth/GoogleOAuthService.java
+++ b/demo/src/main/java/itis/semestrovka/demo/service/oauth/GoogleOAuthService.java
@@ -180,6 +180,7 @@ public class GoogleOAuthService {
         // Генерируем случайный пароль
         String rawPassword = UUID.randomUUID().toString();
         u.setPassword(passwordEncoder.encode(rawPassword));
+        u.setPasswordSet(false);
         u.setRole(Role.ROLE_USER);
 
         // 3) Сохраняем в базу

--- a/demo/src/main/resources/templates/auth/set_password.html
+++ b/demo/src/main/resources/templates/auth/set_password.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html lang="ru"
+      xmlns:th="http://www.thymeleaf.org"
+      xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
+      layout:decorate="~{layout}">
+<head>
+  <meta charset="UTF-8"/>
+  <title layout:fragment="title">Установить пароль</title>
+</head>
+<body>
+<div layout:fragment="content">
+  <div class="row justify-content-center mt-4 mb-4">
+    <div class="col-12 col-sm-8 col-md-6 col-lg-4">
+      <div class="card">
+        <div class="card-header">
+          <h3 class="mb-0">Установить пароль</h3>
+        </div>
+        <div class="card-body">
+          <div th:if="${alreadySet}" class="text-center text-success">
+            Пароль уже задан
+          </div>
+          <form th:if="${!alreadySet}" th:action="@{/set-password}" th:object="${form}" method="post" class="needs-validation" novalidate>
+            <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}"/>
+            <div class="mb-3">
+              <label for="password" class="form-label">Пароль</label>
+              <input type="password" id="password" th:field="*{password}" class="form-control" placeholder="Введите пароль" pattern=".{8,}" required>
+              <div class="invalid-feedback">Пароль должен быть не менее 8 символов</div>
+              <div class="text-danger mt-1" th:if="${#fields.hasErrors('password')}" th:errors="*{password}"></div>
+            </div>
+            <button type="submit" class="btn btn-primary w-100">Сохранить</button>
+          </form>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+<script>
+  (() => {
+    'use strict'
+    const forms = document.querySelectorAll('.needs-validation')
+    Array.from(forms).forEach(form => {
+      form.addEventListener('submit', event => {
+        if (!form.checkValidity()) {
+          event.preventDefault()
+          event.stopPropagation()
+        }
+        form.classList.add('was-validated')
+      }, false)
+    })
+  })()
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add `passwordSet` flag to `User`
- allow `UserService` to update password
- register normal users with `passwordSet=true`
- mark Google OAuth registrations with `passwordSet=false`
- new `PasswordController` and `PasswordForm`
- new Thymeleaf page to set password

## Testing
- `mvn -q -DskipTests package` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6842c76777d8832a8ef0497f37240fb0