### PR TITLE
Add password change form

### DIFF
--- a/demo/src/main/java/itis/semestrovka/demo/controller/ChangePasswordController.java
+++ b/demo/src/main/java/itis/semestrovka/demo/controller/ChangePasswordController.java
@@ -1,0 +1,51 @@
+package itis.semestrovka.demo.controller;
+
+import itis.semestrovka.demo.model.dto.ChangePasswordForm;
+import itis.semestrovka.demo.model.entity.User;
+import itis.semestrovka.demo.service.UserService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@Controller
+@RequestMapping("/change-password")
+@RequiredArgsConstructor
+public class ChangePasswordController {
+
+    private final UserService userService;
+    private final PasswordEncoder passwordEncoder;
+
+    @GetMapping
+    public String form(Model model) {
+        model.addAttribute("title", "Сменить пароль");
+        model.addAttribute("form", new ChangePasswordForm());
+        return "auth/change_password";
+    }
+
+    @PostMapping
+    public String change(@Valid @ModelAttribute("form") ChangePasswordForm form,
+                         BindingResult br,
+                         @AuthenticationPrincipal User currentUser,
+                         Model model) {
+        model.addAttribute("title", "Сменить пароль");
+        if (!passwordEncoder.matches(form.getCurrentPassword(), currentUser.getPassword())) {
+            br.rejectValue("currentPassword", "invalid", "Неверный текущий пароль");
+        }
+        if (!form.getNewPassword().equals(form.getConfirmPassword())) {
+            br.rejectValue("confirmPassword", "mismatch", "Пароли не совпадают");
+        }
+        if (br.hasErrors()) {
+            return "auth/change_password";
+        }
+        userService.updatePassword(currentUser, form.getNewPassword());
+        return "redirect:/profile";
+    }
+}

--- a/demo/src/main/java/itis/semestrovka/demo/controller/PasswordController.java
+++ b/demo/src/main/java/itis/semestrovka/demo/controller/PasswordController.java
@@ -24,12 +24,9 @@ public class PasswordController {
     @GetMapping
     public String form(@AuthenticationPrincipal User currentUser, Model model) {
         model.addAttribute("title", "Установить пароль");
-        if (!currentUser.getPhone().startsWith("google-")) {
-            model.addAttribute("alreadySet", true);
-            return "auth/set_password";
-        }
-        if (currentUser.isPasswordSet()) {
-            model.addAttribute("alreadySet", true);
+        boolean alreadySet = !currentUser.getPhone().startsWith("google-") || currentUser.isPasswordSet();
+        model.addAttribute("alreadySet", alreadySet);
+        if (alreadySet) {
             return "auth/set_password";
         }
         model.addAttribute("form", new PasswordForm());
@@ -42,8 +39,9 @@ public class PasswordController {
                        @AuthenticationPrincipal User currentUser,
                        Model model) {
         model.addAttribute("title", "Установить пароль");
-        if (!currentUser.getPhone().startsWith("google-") || currentUser.isPasswordSet()) {
-            model.addAttribute("alreadySet", true);
+        boolean alreadySet = !currentUser.getPhone().startsWith("google-") || currentUser.isPasswordSet();
+        model.addAttribute("alreadySet", alreadySet);
+        if (alreadySet) {
             return "auth/set_password";
         }
         if (br.hasErrors()) {

--- a/demo/src/main/java/itis/semestrovka/demo/model/dto/ChangePasswordForm.java
+++ b/demo/src/main/java/itis/semestrovka/demo/model/dto/ChangePasswordForm.java
@@ -1,0 +1,18 @@
+package itis.semestrovka.demo.model.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Data;
+
+@Data
+public class ChangePasswordForm {
+    @NotBlank(message = "Введите текущий пароль")
+    private String currentPassword;
+
+    @NotBlank(message = "Введите новый пароль")
+    @Size(min = 8, message = "Пароль должен быть не менее 8 символов")
+    private String newPassword;
+
+    @NotBlank(message = "Повторите новый пароль")
+    private String confirmPassword;
+}

--- a/demo/src/main/resources/templates/auth/change_password.html
+++ b/demo/src/main/resources/templates/auth/change_password.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="ru"
+      xmlns:th="http://www.thymeleaf.org"
+      xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
+      layout:decorate="~{layout}">
+<head>
+  <meta charset="UTF-8"/>
+  <title layout:fragment="title">Сменить пароль</title>
+</head>
+<body>
+<div layout:fragment="content">
+  <div class="row justify-content-center mt-4 mb-4">
+    <div class="col-12 col-sm-8 col-md-6 col-lg-4">
+      <div class="card">
+        <div class="card-header">
+          <h3 class="mb-0">Сменить пароль</h3>
+        </div>
+        <div class="card-body">
+          <form th:action="@{/change-password}" th:object="${form}" method="post" class="needs-validation" novalidate>
+            <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}"/>
+
+            <div class="mb-3">
+              <label for="currentPassword" class="form-label">Текущий пароль</label>
+              <input type="password" id="currentPassword" th:field="*{currentPassword}" class="form-control" required>
+              <div class="text-danger mt-1" th:if="${#fields.hasErrors('currentPassword')}" th:errors="*{currentPassword}"></div>
+            </div>
+
+            <div class="mb-3">
+              <label for="newPassword" class="form-label">Новый пароль</label>
+              <input type="password" id="newPassword" th:field="*{newPassword}" class="form-control" pattern=".{8,}" required>
+              <div class="invalid-feedback">Пароль должен быть не менее 8 символов</div>
+              <div class="text-danger mt-1" th:if="${#fields.hasErrors('newPassword')}" th:errors="*{newPassword}"></div>
+            </div>
+
+            <div class="mb-3">
+              <label for="confirmPassword" class="form-label">Повторите новый пароль</label>
+              <input type="password" id="confirmPassword" th:field="*{confirmPassword}" class="form-control" pattern=".{8,}" required>
+              <div class="invalid-feedback">Пароль должен быть не менее 8 символов</div>
+              <div class="text-danger mt-1" th:if="${#fields.hasErrors('confirmPassword')}" th:errors="*{confirmPassword}"></div>
+            </div>
+
+            <button type="submit" class="btn btn-primary w-100">Сменить пароль</button>
+          </form>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+<script>
+  (() => {
+    'use strict'
+    const forms = document.querySelectorAll('.needs-validation')
+    Array.from(forms).forEach(form => {
+      form.addEventListener('submit', event => {
+        if (!form.checkValidity()) {
+          event.preventDefault()
+          event.stopPropagation()
+        }
+        form.classList.add('was-validated')
+      }, false)
+    })
+  })()
+</script>
+</body>
+</html>

--- a/demo/src/main/resources/templates/profile/form.html
+++ b/demo/src/main/resources/templates/profile/form.html
@@ -32,6 +32,8 @@
               <div class="d-flex">
                 <button type="submit" class="btn-success me-2">Сохранить</button>
                 <a th:href="@{/profile}" class="btn-secondary">Отмена</a>
+                <a th:href="@{/set-password}" class="btn btn-primary ms-2">Установить пароль</a>
+                <a th:href="@{/change-password}" class="btn btn-warning ms-2">Сменить пароль</a>
               </div>
             </form>
           </div>


### PR DESCRIPTION
## Summary
- implement `ChangePasswordController` with form validation
- add `ChangePasswordForm` DTO
- new Thymeleaf template `change_password.html`
- link to password change from profile editing page

## Testing
- `./mvnw test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6842f52aac80832a8fc5d6092d705a4e