### PR TITLE
Add team search by partial name

### DIFF
--- a/demo/src/main/java/itis/semestrovka/demo/controller/TeamController.java
+++ b/demo/src/main/java/itis/semestrovka/demo/controller/TeamController.java
@@ -29,9 +29,13 @@ public class TeamController {
 
     /** 1.1. Список всех команд (главная страница раздела «Команды») */
     @GetMapping
-    public String list(Model model) {
-        List<Team> teams = teamService.findAllTeams();
+    public String list(@RequestParam(value = "search", required = false) String search,
+                       Model model) {
+        List<Team> teams = (search != null && !search.isBlank())
+                ? teamService.findByPartialName(search)
+                : teamService.findAllTeams();
         model.addAttribute("teams", teams);
+        model.addAttribute("search", search);
         model.addAttribute("title", "Список команд");
         return "team/list";
     }
@@ -53,9 +57,13 @@ public class TeamController {
     /** 2.1. Страница администрирования (альтернативный список команд для админа) */
     @PreAuthorize("hasRole('ROLE_ADMIN')")
     @GetMapping("/admin")
-    public String adminList(Model model) {
-        List<Team> teams = teamService.findAllTeams();
+    public String adminList(@RequestParam(value = "search", required = false) String search,
+                            Model model) {
+        List<Team> teams = (search != null && !search.isBlank())
+                ? teamService.findByPartialName(search)
+                : teamService.findAllTeams();
         model.addAttribute("teams", teams);
+        model.addAttribute("search", search);
         model.addAttribute("title", "Управление командами");
         return "team/admin_list";
     }

--- a/demo/src/main/java/itis/semestrovka/demo/repository/TeamRepository.java
+++ b/demo/src/main/java/itis/semestrovka/demo/repository/TeamRepository.java
@@ -17,4 +17,11 @@ public interface TeamRepository extends JpaRepository<Team, Long> {
      */
     @Query("SELECT t FROM Team t LEFT JOIN FETCH t.members WHERE t.id = :id")
     Optional<Team> findByIdWithMembers(@Param("id") Long id);
+
+    /**
+     * Найти команды, чьё название содержит указанную подстроку,
+     * упорядочив их по дате создания от новых к старым.
+     */
+    @Query("SELECT t FROM Team t WHERE LOWER(t.name) LIKE LOWER(CONCAT('%', :name, '%')) ORDER BY t.createdAt DESC")
+    java.util.List<Team> findByPartialName(@Param("name") String name);
 }

--- a/demo/src/main/java/itis/semestrovka/demo/service/TeamService.java
+++ b/demo/src/main/java/itis/semestrovka/demo/service/TeamService.java
@@ -14,6 +14,11 @@ public interface TeamService {
     Team create(Team t);
     void deleteById(Long id);
 
+    /**
+     * Поиск команд по подстроке в названии.
+     */
+    java.util.List<Team> findByPartialName(String name);
+
     /* ---- ДОБАВЛЯЕМ ---- */
     List<User> findAllUsers();
 

--- a/demo/src/main/java/itis/semestrovka/demo/service/impl/TeamServiceImpl.java
+++ b/demo/src/main/java/itis/semestrovka/demo/service/impl/TeamServiceImpl.java
@@ -33,6 +33,11 @@ public class TeamServiceImpl implements TeamService {
     @Override public Team create(Team t)         { return teamRepo.save(t); }
     @Override public void deleteById(Long id)    { teamRepo.deleteById(id); }
 
+    @Override
+    public java.util.List<Team> findByPartialName(String name) {
+        return teamRepo.findByPartialName(name);
+    }
+
     /* ---------- НОВЫЕ МЕТОДЫ ---------- */
 
     @Override

--- a/demo/src/main/resources/templates/team/admin_list.html
+++ b/demo/src/main/resources/templates/team/admin_list.html
@@ -17,8 +17,12 @@
       <div class="col-md-10">
         <div class="card">
           <!-- Шапка карточки -->
-          <div class="card-header">
+          <div class="card-header d-flex justify-content-between align-items-center gap-2 flex-wrap">
             <h3 class="mb-0" th:text="${title}">Управление командами</h3>
+            <form th:action="@{/teams/admin}" method="get" class="d-flex align-items-center" style="gap:0.5rem;">
+              <input type="text" name="search" class="form-control form-control-sm" placeholder="Поиск" th:value="${search}">
+              <button type="submit" class="btn btn-primary btn-sm">Найти</button>
+            </form>
             <div class="d-flex gap-2">
               <a th:href="@{/teams/new}" class="btn-success btn-sm">Создать команду</a>
               <a th:href="@{/teams}" class="btn-outline-light btn-sm">Назад к списку</a>

--- a/demo/src/main/resources/templates/team/list.html
+++ b/demo/src/main/resources/templates/team/list.html
@@ -20,8 +20,13 @@
             <div class="card">
 
                 <!-- Шапка карточки -->
-                <div class="card-header d-flex justify-content-between align-items-center">
+                <div class="card-header d-flex justify-content-between align-items-center gap-2 flex-wrap">
                     <h3 class="mb-0" th:text="${title}">Список команд</h3>
+
+                    <form th:action="@{/teams}" method="get" class="d-flex align-items-center ms-auto" style="gap:0.5rem;">
+                        <input type="text" name="search" class="form-control form-control-sm" placeholder="Поиск" th:value="${search}">
+                        <button type="submit" class="btn btn-primary btn-sm">Найти</button>
+                    </form>
 
                     <a th:if="${#authorization.expression('hasRole(''ADMIN'')')}"
                        th:href="@{/teams/admin}"


### PR DESCRIPTION
## Summary
- add JPQL query in `TeamRepository` for searching by partial name
- expose search method in `TeamService` and implementation
- support optional search parameter in `TeamController`
- add search forms to team list views

## Testing
- `./mvnw test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_684300010808832a93f5fa7a352cae1a