### PR TITLE
Add Swagger support

### DIFF
--- a/demo/pom.xml
+++ b/demo/pom.xml
@@ -61,11 +61,17 @@
                         <scope>provided</scope>
                 </dependency>
 			<!-- https://mvnrepository.com/artifact/jakarta.validation/jakarta.validation-api -->
-			<dependency>
-				<groupId>jakarta.validation</groupId>
-				<artifactId>jakarta.validation-api</artifactId>
-				<version>3.1.1</version>
-			</dependency>
+                <dependency>
+                        <groupId>jakarta.validation</groupId>
+                        <artifactId>jakarta.validation-api</artifactId>
+                        <version>3.1.1</version>
+                </dependency>
+                <!-- OpenAPI / Swagger support -->
+                <dependency>
+                        <groupId>org.springdoc</groupId>
+                        <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+                        <version>2.5.0</version>
+                </dependency>
         </dependencies>
 
 	<build>

--- a/demo/src/main/java/itis/semestrovka/demo/config/OpenApiConfig.java
+++ b/demo/src/main/java/itis/semestrovka/demo/config/OpenApiConfig.java
@@ -1,0 +1,19 @@
+package itis.semestrovka.demo.config;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class OpenApiConfig {
+
+    @Bean
+    public OpenAPI customOpenAPI() {
+        return new OpenAPI()
+                .info(new Info()
+                        .title("TeamManager API")
+                        .version("v1")
+                        .description("Documentation for REST endpoints"));
+    }
+}

--- a/demo/src/main/java/itis/semestrovka/demo/config/SecurityConfig.java
+++ b/demo/src/main/java/itis/semestrovka/demo/config/SecurityConfig.java
@@ -38,7 +38,16 @@ public class SecurityConfig {
         http
                 .authenticationProvider(authProvider())
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/login", "/register", "/css/**", "/js/**", "/oauth2/**").permitAll()
+                        .requestMatchers(
+                                "/login",
+                                "/register",
+                                "/css/**",
+                                "/js/**",
+                                "/oauth2/**",
+                                "/v3/api-docs/**",
+                                "/swagger-ui.html",
+                                "/swagger-ui/**"
+                        ).permitAll()
                         .anyRequest().authenticated()
                 )
                 .formLogin(form -> form

--- a/demo/src/main/resources/application.yaml
+++ b/demo/src/main/resources/application.yaml
@@ -29,3 +29,8 @@ slack:
 
 
 
+
+springdoc:
+  swagger-ui:
+    path: /swagger-ui.html
+


### PR DESCRIPTION
## Summary
- add springdoc-openapi starter
- configure OpenAPI bean
- permit swagger endpoints in security configuration
- expose swagger-ui at `/swagger-ui.html`

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM due to network)*

------
https://chatgpt.com/codex/tasks/task_e_684307e86728832a8ad6f514394f2e07