### PR TITLE
Set assigned user when creating task

### DIFF
--- a/demo/src/main/java/itis/semestrovka/demo/controller/TaskController.java
+++ b/demo/src/main/java/itis/semestrovka/demo/controller/TaskController.java
@@ -84,9 +84,14 @@ public class TaskController {
             return "task/form";
         }
 
-        // Привязка к проекту и исполнителю ------------------------------
+        // Привязка к проекту
         Project project = projectService.findById(projectId);
         task.setProject(project);
+
+        // При создании задачи назначаем исполнителем автора
+        if (task.getId() == null) {
+            task.setAssignedUser(currentUser);
+        }
 
 
 


### PR DESCRIPTION
## Summary
- automatically assign the current user as the task's assignee when creating a task

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM due to network)*

------
https://chatgpt.com/codex/tasks/task_e_6843155e9eac832a905d4f5a8dbc14e4