### PR TITLE
Implement REST task operations

### DIFF
--- a/demo/src/main/java/itis/semestrovka/demo/controller/TaskController.java
+++ b/demo/src/main/java/itis/semestrovka/demo/controller/TaskController.java
@@ -16,6 +16,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Controller;
+import io.swagger.v3.oas.annotations.Hidden;
 import org.springframework.ui.Model;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.*;
@@ -25,6 +26,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.HashSet;
 
+@Hidden
 @Controller
 @RequestMapping("/projects/{projectId}/tasks")
 @RequiredArgsConstructor

--- a/demo/src/main/java/itis/semestrovka/demo/service/impl/TaskServiceImpl.java
+++ b/demo/src/main/java/itis/semestrovka/demo/service/impl/TaskServiceImpl.java
@@ -5,6 +5,7 @@ import itis.semestrovka.demo.model.dto.TaskDto;
 import itis.semestrovka.demo.model.entity.Project;
 import itis.semestrovka.demo.model.entity.Task;
 import itis.semestrovka.demo.repository.TaskRepository;
+import itis.semestrovka.demo.repository.UserRepository;
 import itis.semestrovka.demo.service.TaskService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -18,6 +19,7 @@ import java.util.List;
 public class TaskServiceImpl implements TaskService {
 
     private final TaskRepository repo;
+    private final UserRepository userRepo;
 
     /* ===== MVC ===== */
 
@@ -51,15 +53,25 @@ public class TaskServiceImpl implements TaskService {
         return repo.findAllByParticipants_Id(userId);
     }
 
-    /* ===== REST / AJAX (заглушки) ===== */
+    /* ===== REST / AJAX ===== */
 
     @Override
     public Task create(Project project, TaskDto dto) {
-        throw new UnsupportedOperationException("REST-метод пока не используется");
+        Task task = new Task();
+        task.setProject(project);
+        task.setTitle(dto.getTitle());
+        task.setStatus(dto.getStatus());
+
+        if (dto.getAssignedUsername() != null) {
+            userRepo.findByUsername(dto.getAssignedUsername())
+                    .ifPresent(task::setAssignedUser);
+        }
+
+        return repo.save(task);
     }
 
     @Override
     public void delete(Long projectId, Long taskId) {
-        throw new UnsupportedOperationException("REST-метод пока не используется");
+        repo.deleteByIdAndProjectId(taskId, projectId);
     }
 }


### PR DESCRIPTION
## Summary
- hide MVC TaskController from Swagger
- implement REST create/delete methods in TaskServiceImpl

## Testing
- `./mvnw test` *(fails: Non-resolvable parent POM due to network)*

------
https://chatgpt.com/codex/tasks/task_e_68432a6a3590832aa20c527983e3a396