### PR TITLE
Add entity to DTO converters

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,14 @@ After launch, open `http://localhost:8080/login` and use the "Войти чер�
 After Google authentication a new account will be created if it does not exist. The generated username and password will be automatically inserted into the login form so you can sign in immediately.
 
 
+
+## DTO conversion
+
+Separate converter classes are used to transform entities into DTOs and back. For example, `TaskConverter` converts between `Task` and `TaskDto` objects:
+
+```java
+Task task = TaskConverter.toEntity(dto);
+TaskDto dto = TaskConverter.toDto(task);
+```
+
+`TaskConverter` is invoked from `TaskServiceImpl#create` when a new task is created through the REST API.

--- a/demo/src/main/java/itis/semestrovka/demo/controller/TaskRestController.java
+++ b/demo/src/main/java/itis/semestrovka/demo/controller/TaskRestController.java
@@ -4,6 +4,7 @@ import itis.semestrovka.demo.model.dto.TaskDto;
 import itis.semestrovka.demo.model.entity.Project;
 import itis.semestrovka.demo.model.entity.Task;
 import itis.semestrovka.demo.model.entity.User;
+import itis.semestrovka.demo.mapper.TaskConverter;
 import itis.semestrovka.demo.service.ProjectService;
 import itis.semestrovka.demo.service.TaskService;
 import itis.semestrovka.demo.service.UserService;
@@ -47,7 +48,7 @@ public class TaskRestController {
         }
 
         Task task = taskService.create(project, dto);
-        return TaskDto.from(task);
+        return TaskConverter.toDto(task);
     }
 
     /* ----------  DELETE ЗАДАЧИ  ---------- */

--- a/demo/src/main/java/itis/semestrovka/demo/mapper/TaskConverter.java
+++ b/demo/src/main/java/itis/semestrovka/demo/mapper/TaskConverter.java
@@ -1,0 +1,43 @@
+package itis.semestrovka.demo.mapper;
+
+import itis.semestrovka.demo.model.dto.TaskDto;
+import itis.semestrovka.demo.model.entity.Task;
+import itis.semestrovka.demo.model.entity.User;
+
+/**
+ * Converter for {@link Task} and {@link TaskDto}.
+ * <p>
+ * Example usage:
+ * {@code Task task = TaskConverter.toEntity(dto);}
+ * {@code TaskDto dto = TaskConverter.toDto(task);}
+ */
+public class TaskConverter {
+
+    /** Convert Task entity to DTO. */
+    public static TaskDto toDto(Task task) {
+        if (task == null) return null;
+        TaskDto dto = new TaskDto();
+        dto.setId(task.getId());
+        dto.setTitle(task.getTitle());
+        dto.setStatus(task.getStatus());
+        if (task.getAssignedUser() != null) {
+            dto.setAssignedUsername(task.getAssignedUser().getUsername());
+        }
+        return dto;
+    }
+
+    /** Convert DTO to Task entity (without setting project). */
+    public static Task toEntity(TaskDto dto) {
+        if (dto == null) return null;
+        Task task = new Task();
+        task.setId(dto.getId());
+        task.setTitle(dto.getTitle());
+        task.setStatus(dto.getStatus());
+        if (dto.getAssignedUsername() != null) {
+            User user = new User();
+            user.setUsername(dto.getAssignedUsername());
+            task.setAssignedUser(user);
+        }
+        return task;
+    }
+}

--- a/demo/src/main/java/itis/semestrovka/demo/mapper/TeamConverter.java
+++ b/demo/src/main/java/itis/semestrovka/demo/mapper/TeamConverter.java
@@ -1,0 +1,30 @@
+package itis.semestrovka.demo.mapper;
+
+import itis.semestrovka.demo.model.dto.TeamDto;
+import itis.semestrovka.demo.model.entity.Team;
+
+/**
+ * Converter for {@link Team} and {@link TeamDto}.
+ */
+public class TeamConverter {
+
+    /** Convert Team entity to DTO. */
+    public static TeamDto toDto(Team team) {
+        if (team == null) return null;
+        TeamDto dto = new TeamDto();
+        dto.setId(team.getId());
+        dto.setName(team.getName());
+        dto.setDescription(team.getDescription());
+        return dto;
+    }
+
+    /** Convert DTO to Team entity. */
+    public static Team toEntity(TeamDto dto) {
+        if (dto == null) return null;
+        Team team = new Team();
+        team.setId(dto.getId());
+        team.setName(dto.getName());
+        team.setDescription(dto.getDescription());
+        return team;
+    }
+}

--- a/demo/src/main/java/itis/semestrovka/demo/mapper/UserConverter.java
+++ b/demo/src/main/java/itis/semestrovka/demo/mapper/UserConverter.java
@@ -1,0 +1,36 @@
+package itis.semestrovka.demo.mapper;
+
+import itis.semestrovka.demo.model.dto.UserDto;
+import itis.semestrovka.demo.model.entity.User;
+
+/**
+ * Converter for {@link User} and {@link UserDto}.
+ */
+public class UserConverter {
+
+    /** Convert User entity to DTO. */
+    public static UserDto toDto(User user) {
+        if (user == null) return null;
+        UserDto dto = new UserDto();
+        dto.setId(user.getId());
+        dto.setUsername(user.getUsername());
+        dto.setEmail(user.getEmail());
+        dto.setPhone(user.getPhone());
+        dto.setRole(user.getRole().name());
+        if (user.getTeam() != null) {
+            dto.setTeamId(user.getTeam().getId());
+        }
+        return dto;
+    }
+
+    /** Convert DTO to User entity. */
+    public static User toEntity(UserDto dto) {
+        if (dto == null) return null;
+        User user = new User();
+        user.setId(dto.getId());
+        user.setUsername(dto.getUsername());
+        user.setEmail(dto.getEmail());
+        user.setPhone(dto.getPhone());
+        return user;
+    }
+}

--- a/demo/src/main/java/itis/semestrovka/demo/model/dto/TeamDto.java
+++ b/demo/src/main/java/itis/semestrovka/demo/model/dto/TeamDto.java
@@ -1,0 +1,13 @@
+package itis.semestrovka.demo.model.dto;
+
+import lombok.Data;
+
+/**
+ * Data transfer object for {@link itis.semestrovka.demo.model.entity.Team}.
+ */
+@Data
+public class TeamDto {
+    private Long id;
+    private String name;
+    private String description;
+}

--- a/demo/src/main/java/itis/semestrovka/demo/model/dto/UserDto.java
+++ b/demo/src/main/java/itis/semestrovka/demo/model/dto/UserDto.java
@@ -1,0 +1,16 @@
+package itis.semestrovka.demo.model.dto;
+
+import lombok.Data;
+
+/**
+ * Data transfer object for {@link itis.semestrovka.demo.model.entity.User}.
+ */
+@Data
+public class UserDto {
+    private Long id;
+    private String username;
+    private String email;
+    private String phone;
+    private String role;
+    private Long teamId;
+}

--- a/demo/src/main/java/itis/semestrovka/demo/service/impl/TaskServiceImpl.java
+++ b/demo/src/main/java/itis/semestrovka/demo/service/impl/TaskServiceImpl.java
@@ -4,6 +4,7 @@ package itis.semestrovka.demo.service.impl;
 import itis.semestrovka.demo.model.dto.TaskDto;
 import itis.semestrovka.demo.model.entity.Project;
 import itis.semestrovka.demo.model.entity.Task;
+import itis.semestrovka.demo.mapper.TaskConverter;
 import itis.semestrovka.demo.repository.TaskRepository;
 import itis.semestrovka.demo.repository.UserRepository;
 import itis.semestrovka.demo.service.TaskService;
@@ -57,11 +58,11 @@ public class TaskServiceImpl implements TaskService {
 
     @Override
     public Task create(Project project, TaskDto dto) {
-        Task task = new Task();
+        // Преобразуем DTO в сущность с помощью конвертера
+        Task task = TaskConverter.toEntity(dto);
         task.setProject(project);
-        task.setTitle(dto.getTitle());
-        task.setStatus(dto.getStatus());
 
+        // Назначение пользователя осуществляется через репозиторий
         if (dto.getAssignedUsername() != null) {
             userRepo.findByUsername(dto.getAssignedUsername())
                     .ifPresent(task::setAssignedUser);


### PR DESCRIPTION
## Summary
- introduce `TaskConverter`, `UserConverter`, and `TeamConverter`
- create `UserDto` and `TeamDto`
- use `TaskConverter` in `TaskServiceImpl` and `TaskRestController`
- document conversion usage in README

## Testing
- `mvn -q -DskipTests package` *(fails: Non-resolvable parent POM due to network)*

------
https://chatgpt.com/codex/tasks/task_e_68434425f550832aac7cb755eaa54a04