### PR TITLE
Add TeamConverter usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,5 @@ TaskDto dto = TaskConverter.toDto(task);
 ```
 
 `TaskConverter` is invoked from `TaskServiceImpl#create` when a new task is created through the REST API.
+
+`TeamConverter` is used in `TeamRestController` to expose REST endpoints that work with `TeamDto` objects.

--- a/demo/src/main/java/itis/semestrovka/demo/controller/TeamRestController.java
+++ b/demo/src/main/java/itis/semestrovka/demo/controller/TeamRestController.java
@@ -1,6 +1,8 @@
 package itis.semestrovka.demo.controller;
 
 import itis.semestrovka.demo.service.TeamService;
+import itis.semestrovka.demo.model.dto.TeamDto;
+import itis.semestrovka.demo.mapper.TeamConverter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -14,6 +16,27 @@ import org.springframework.web.bind.annotation.*;
 public class TeamRestController {
 
     private final TeamService teamService;
+
+    /** Получить список всех команд. */
+    @GetMapping
+    public java.util.List<TeamDto> getAll() {
+        return teamService.findAllTeams().stream()
+                .map(TeamConverter::toDto)
+                .toList();
+    }
+
+    /** Создать новую команду. */
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public TeamDto create(@RequestBody TeamDto dto) {
+        return TeamConverter.toDto(teamService.create(TeamConverter.toEntity(dto)));
+    }
+
+    /** Получить конкретную команду по id. */
+    @GetMapping("/{id}")
+    public TeamDto getById(@PathVariable Long id) {
+        return TeamConverter.toDto(teamService.findById(id));
+    }
 
     /** Удаление пользователя из команды через AJAX */
     @DeleteMapping("/{teamId}/users/{userId}")


### PR DESCRIPTION
## Summary
- expose `/api/teams` REST endpoints returning `TeamDto`
- mention `TeamConverter` usage in README

## Testing
- `./mvnw test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68434815d4cc832a83064a8bb1fd0839