### PR TITLE
Add SLF4J logging

### DIFF
--- a/demo/src/main/java/itis/semestrovka/demo/config/AuthenticationEventListener.java
+++ b/demo/src/main/java/itis/semestrovka/demo/config/AuthenticationEventListener.java
@@ -1,0 +1,28 @@
+package itis.semestrovka.demo.config;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.event.EventListener;
+import org.springframework.security.authentication.event.AbstractAuthenticationFailureEvent;
+import org.springframework.security.authentication.event.AuthenticationSuccessEvent;
+import org.springframework.stereotype.Component;
+
+/**
+ * Logs authentication success and failure events.
+ */
+@Component
+public class AuthenticationEventListener {
+    private static final Logger log = LoggerFactory.getLogger(AuthenticationEventListener.class);
+
+    @EventListener
+    public void onSuccess(AuthenticationSuccessEvent event) {
+        String username = event.getAuthentication().getName();
+        log.info("User '{}' logged in successfully", username);
+    }
+
+    @EventListener
+    public void onFailure(AbstractAuthenticationFailureEvent event) {
+        String username = event.getAuthentication().getName();
+        log.warn("Failed login attempt for user '{}'", username);
+    }
+}

--- a/demo/src/main/java/itis/semestrovka/demo/exception/GlobalExceptionHandler.java
+++ b/demo/src/main/java/itis/semestrovka/demo/exception/GlobalExceptionHandler.java
@@ -2,6 +2,8 @@ package itis.semestrovka.demo.exception;
 
 import jakarta.persistence.EntityNotFoundException;
 import jakarta.servlet.http.HttpServletRequest;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
@@ -16,6 +18,8 @@ import org.springframework.web.servlet.ModelAndView;
  */
 @ControllerAdvice
 public class GlobalExceptionHandler {
+
+    private static final Logger log = LoggerFactory.getLogger(GlobalExceptionHandler.class);
 
     private boolean isApiRequest(HttpServletRequest request) {
         return request.getRequestURI().startsWith("/api");
@@ -37,21 +41,25 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(EntityNotFoundException.class)
     public Object handleEntityNotFound(EntityNotFoundException ex, HttpServletRequest request) {
+        log.warn("Entity not found: {}", ex.getMessage());
         return buildResponse(HttpStatus.NOT_FOUND, ex.getMessage(), request);
     }
 
     @ExceptionHandler(IllegalArgumentException.class)
     public Object handleIllegalArgument(IllegalArgumentException ex, HttpServletRequest request) {
+        log.warn("Illegal argument: {}", ex.getMessage());
         return buildResponse(HttpStatus.BAD_REQUEST, ex.getMessage(), request);
     }
 
     @ExceptionHandler(ResponseStatusException.class)
     public Object handleResponseStatus(ResponseStatusException ex, HttpServletRequest request) {
+        log.error("ResponseStatus exception: {}", ex.getMessage());
         return buildResponse(ex.getStatusCode(), ex.getReason() != null ? ex.getReason() : ex.getMessage(), request);
     }
 
     @ExceptionHandler(Exception.class)
     public Object handleOtherExceptions(Exception ex, HttpServletRequest request) {
+        log.error("Unhandled exception", ex);
         return buildResponse(HttpStatus.INTERNAL_SERVER_ERROR, ex.getMessage(), request);
     }
 }

--- a/demo/src/main/java/itis/semestrovka/demo/service/impl/TaskServiceImpl.java
+++ b/demo/src/main/java/itis/semestrovka/demo/service/impl/TaskServiceImpl.java
@@ -9,6 +9,8 @@ import itis.semestrovka.demo.repository.TaskRepository;
 import itis.semestrovka.demo.repository.UserRepository;
 import itis.semestrovka.demo.service.TaskService;
 import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -21,12 +23,15 @@ public class TaskServiceImpl implements TaskService {
 
     private final TaskRepository repo;
     private final UserRepository userRepo;
+    private static final Logger log = LoggerFactory.getLogger(TaskServiceImpl.class);
 
     /* ===== MVC ===== */
 
     @Override
     public Task save(Task task) {
-        return repo.save(task);
+        Task saved = repo.save(task);
+        log.info("Saved task with id={}", saved.getId());
+        return saved;
     }
 
     @Override
@@ -37,6 +42,7 @@ public class TaskServiceImpl implements TaskService {
     @Override
     public void deleteById(Long id) {
         repo.deleteById(id);
+        log.info("Deleted task with id={}", id);
     }
 
     @Override
@@ -65,14 +71,18 @@ public class TaskServiceImpl implements TaskService {
         // Назначение пользователя осуществляется через репозиторий
         if (dto.getAssignedUsername() != null) {
             userRepo.findByUsername(dto.getAssignedUsername())
-                    .ifPresent(task::setAssignedUser);
+                    .ifPresentOrElse(task::setAssignedUser,
+                            () -> log.warn("User '{}' not found for assignment", dto.getAssignedUsername()));
         }
 
-        return repo.save(task);
+        Task saved = repo.save(task);
+        log.info("Created task with id={} in project={}", saved.getId(), project.getId());
+        return saved;
     }
 
     @Override
     public void delete(Long projectId, Long taskId) {
         repo.deleteByIdAndProjectId(taskId, projectId);
+        log.info("Deleted task with id={} from project={}", taskId, projectId);
     }
 }


### PR DESCRIPTION
## Summary
- log authentication events using `AuthenticationEventListener`
- add logging statements in `TaskServiceImpl`
- log warnings and errors inside `GlobalExceptionHandler`

## Testing
- `./mvnw test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68434ef84804832a8bf435c912ba4dfc