### PR TITLE
Add unit tests for service, repository and controller

### DIFF
--- a/demo/pom.xml
+++ b/demo/pom.xml
@@ -67,11 +67,28 @@
                         <version>3.1.1</version>
                 </dependency>
                 <!-- OpenAPI / Swagger support -->
-			<dependency>
-				<groupId>org.springdoc</groupId>
-				<artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
-				<version>2.8.6</version>
-			</dependency>
+                        <dependency>
+                                <groupId>org.springdoc</groupId>
+                                <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+                                <version>2.8.6</version>
+                        </dependency>
+
+                <!-- ========= Testing dependencies ========= -->
+                <dependency>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-starter-test</artifactId>
+                        <scope>test</scope>
+                </dependency>
+                <dependency>
+                        <groupId>org.springframework.security</groupId>
+                        <artifactId>spring-security-test</artifactId>
+                        <scope>test</scope>
+                </dependency>
+                <dependency>
+                        <groupId>com.h2database</groupId>
+                        <artifactId>h2</artifactId>
+                        <scope>test</scope>
+                </dependency>
 
 
 

--- a/demo/src/test/java/itis/semestrovka/demo/controller/TaskRestControllerTest.java
+++ b/demo/src/test/java/itis/semestrovka/demo/controller/TaskRestControllerTest.java
@@ -1,0 +1,78 @@
+package itis.semestrovka.demo.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import itis.semestrovka.demo.model.dto.TaskDto;
+import itis.semestrovka.demo.model.entity.Project;
+import itis.semestrovka.demo.model.entity.Task;
+import itis.semestrovka.demo.model.entity.User;
+import itis.semestrovka.demo.service.ProjectService;
+import itis.semestrovka.demo.service.TaskService;
+import itis.semestrovka.demo.service.UserService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(TaskRestController.class)
+class TaskRestControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private TaskService taskService;
+    @MockBean
+    private ProjectService projectService;
+    @MockBean
+    private UserService userService;
+
+    @Test
+    @WithMockUser(username = "owner")
+    void createReturnsCreatedTask() throws Exception {
+        Project project = new Project();
+        User owner = new User();
+        owner.setUsername("owner");
+        project.setOwner(owner);
+        when(projectService.findById(1L)).thenReturn(project);
+
+        TaskDto dto = new TaskDto();
+        dto.setTitle("New Task");
+        Task saved = new Task();
+        saved.setId(5L);
+        when(taskService.create(any(Project.class), any(TaskDto.class))).thenReturn(saved);
+
+        mockMvc.perform(post("/api/projects/1/tasks")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(dto)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(5));
+
+        verify(taskService).create(eq(project), any(TaskDto.class));
+    }
+
+    @Test
+    @WithMockUser(username = "owner")
+    void deleteCallsServiceAndReturnsNoContent() throws Exception {
+        Project project = new Project();
+        User owner = new User();
+        owner.setUsername("owner");
+        project.setOwner(owner);
+        when(projectService.findById(1L)).thenReturn(project);
+
+        mockMvc.perform(delete("/api/projects/1/tasks/2"))
+                .andExpect(status().isNoContent());
+
+        verify(taskService).delete(1L, 2L);
+    }
+}

--- a/demo/src/test/java/itis/semestrovka/demo/repository/TeamRepositoryTest.java
+++ b/demo/src/test/java/itis/semestrovka/demo/repository/TeamRepositoryTest.java
@@ -1,0 +1,69 @@
+package itis.semestrovka.demo.repository;
+
+import itis.semestrovka.demo.model.entity.Role;
+import itis.semestrovka.demo.model.entity.Team;
+import itis.semestrovka.demo.model.entity.User;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+class TeamRepositoryTest {
+
+    @Autowired
+    private TeamRepository teamRepository;
+
+    @Autowired
+    private TestEntityManager em;
+
+    @Test
+    @DisplayName("findByIdWithMembers should return team with users")
+    void findByIdWithMembers() {
+        Team team = new Team();
+        team.setName("Alpha");
+
+        User user = new User();
+        user.setUsername("u1");
+        user.setEmail("u1@mail.ru");
+        user.setPhone("123");
+        user.setPassword("pass");
+        user.setRole(Role.ROLE_USER);
+        user.setTeam(team);
+        team.getMembers().add(user);
+
+        em.persist(team);
+        em.flush();
+
+        Team found = teamRepository.findByIdWithMembers(team.getId()).orElseThrow();
+        assertThat(found.getMembers()).hasSize(1);
+        assertThat(found.getMembers().get(0).getUsername()).isEqualTo("u1");
+    }
+
+    @Test
+    @DisplayName("findByPartialName should search and sort")
+    void findByPartialName() {
+        Team older = new Team();
+        older.setName("My Team");
+        older.setCreatedAt(LocalDateTime.now().minusHours(2));
+
+        Team newer = new Team();
+        newer.setName("Team Rocket");
+        newer.setCreatedAt(LocalDateTime.now());
+
+        em.persist(older);
+        em.persist(newer);
+        em.flush();
+
+        List<Team> result = teamRepository.findByPartialName("team");
+        assertThat(result).hasSize(2);
+        assertThat(result.get(0).getName()).isEqualTo("Team Rocket");
+        assertThat(result.get(1).getName()).isEqualTo("My Team");
+    }
+}

--- a/demo/src/test/java/itis/semestrovka/demo/service/TaskServiceTest.java
+++ b/demo/src/test/java/itis/semestrovka/demo/service/TaskServiceTest.java
@@ -1,0 +1,68 @@
+package itis.semestrovka.demo.service;
+
+import itis.semestrovka.demo.model.dto.TaskDto;
+import itis.semestrovka.demo.model.entity.Project;
+import itis.semestrovka.demo.model.entity.Task;
+import itis.semestrovka.demo.model.entity.User;
+import itis.semestrovka.demo.repository.TaskRepository;
+import itis.semestrovka.demo.repository.UserRepository;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@SpringBootTest
+class TaskServiceTest {
+
+    @Autowired
+    private TaskService taskService;
+
+    @MockBean
+    private TaskRepository taskRepository;
+
+    @MockBean
+    private UserRepository userRepository;
+
+    @Test
+    void createSetsAssignedUserWhenFound() {
+        Project project = new Project();
+        project.setId(1L);
+
+        TaskDto dto = new TaskDto();
+        dto.setTitle("Test");
+        dto.setAssignedUsername("john");
+
+        User user = new User();
+        user.setId(5L);
+        user.setUsername("john");
+        when(userRepository.findByUsername("john")).thenReturn(Optional.of(user));
+
+        ArgumentCaptor<Task> captor = ArgumentCaptor.forClass(Task.class);
+        when(taskRepository.save(any(Task.class))).thenAnswer(inv -> {
+            Task t = inv.getArgument(0);
+            t.setId(10L);
+            return t;
+        });
+
+        Task result = taskService.create(project, dto);
+
+        verify(taskRepository).save(captor.capture());
+        Task saved = captor.getValue();
+        assertThat(saved.getProject()).isEqualTo(project);
+        assertThat(saved.getAssignedUser()).isEqualTo(user);
+        assertThat(result.getId()).isEqualTo(10L);
+    }
+
+    @Test
+    void deleteDelegatesToRepository() {
+        taskService.delete(1L, 2L);
+        verify(taskRepository).deleteByIdAndProjectId(2L, 1L);
+    }
+}


### PR DESCRIPTION
## Summary
- add testing dependencies
- test TaskService business logic
- test TeamRepository queries with DataJpaTest
- test TaskRestController endpoints with WebMvcTest

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM due to network)*

------
https://chatgpt.com/codex/tasks/task_e_6843563d47b8832a9e5e9470f9862706