### PR TITLE
Add Swagger docs and API tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,3 +36,13 @@ TaskDto dto = TaskConverter.toDto(task);
 `TaskConverter` is invoked from `TaskServiceImpl#create` when a new task is created through the REST API.
 
 `TeamConverter` is used in `TeamRestController` to expose REST endpoints that work with `TeamDto` objects.
+
+## REST API and Swagger
+
+All REST endpoints are grouped under the `/api/**` path. The API documentation
+is generated using **springdoc-openapi** and is available at
+`http://localhost:8080/swagger-ui.html` once the application is running.
+
+Example HTTP request files for `TeamRestController` and `TaskRestController` can
+be found in the `demo/http` directory. They can be executed from IntelliJ IDEA
+or imported into tools like Postman.

--- a/demo/http/task-api.http
+++ b/demo/http/task-api.http
@@ -1,0 +1,21 @@
+### Create task
+POST http://localhost:8080/api/projects/1/tasks
+Content-Type: application/json
+X-CSRF-TOKEN: {{_csrf}}
+
+{
+  "title": "Task title",
+  "description": "Optional desc"
+}
+
+### Delete task
+DELETE http://localhost:8080/api/projects/1/tasks/2
+X-CSRF-TOKEN: {{_csrf}}
+
+### Add participant
+POST http://localhost:8080/api/projects/1/tasks/2/participants/3
+X-CSRF-TOKEN: {{_csrf}}
+
+### Remove participant
+DELETE http://localhost:8080/api/projects/1/tasks/2/participants/3
+X-CSRF-TOKEN: {{_csrf}}

--- a/demo/http/team-api.http
+++ b/demo/http/team-api.http
@@ -1,0 +1,21 @@
+### Get all teams
+GET http://localhost:8080/api/teams
+X-CSRF-TOKEN: {{_csrf}}
+
+### Create a team
+POST http://localhost:8080/api/teams
+Content-Type: application/json
+X-CSRF-TOKEN: {{_csrf}}
+
+{
+  "name": "New team",
+  "description": "Optional description"
+}
+
+### Get team by id
+GET http://localhost:8080/api/teams/1
+X-CSRF-TOKEN: {{_csrf}}
+
+### Remove user from team
+DELETE http://localhost:8080/api/teams/1/users/2
+X-CSRF-TOKEN: {{_csrf}}

--- a/demo/src/main/java/itis/semestrovka/demo/controller/TaskRestController.java
+++ b/demo/src/main/java/itis/semestrovka/demo/controller/TaskRestController.java
@@ -8,6 +8,8 @@ import itis.semestrovka.demo.mapper.TaskConverter;
 import itis.semestrovka.demo.service.ProjectService;
 import itis.semestrovka.demo.service.TaskService;
 import itis.semestrovka.demo.service.UserService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -21,6 +23,7 @@ import java.security.Principal;
 @RequiredArgsConstructor
 @RequestMapping("/api/projects/{projectId}/tasks")
 @io.swagger.v3.oas.annotations.security.SecurityRequirement(name = "X-CSRF-TOKEN")
+@Tag(name = "Tasks", description = "Operations with project tasks")
 public class TaskRestController {
 
     private final TaskService    taskService;
@@ -30,6 +33,7 @@ public class TaskRestController {
     /* ----------  CREATE ЗАДАЧИ  ---------- */
     // POST /api/projects/{projectId}/tasks
     @PostMapping
+    @Operation(summary = "Create task")
     public TaskDto create(@PathVariable Long projectId,
                           @RequestBody @Valid TaskDto dto,
                           Principal principal) {
@@ -44,6 +48,7 @@ public class TaskRestController {
     /* ----------  DELETE ЗАДАЧИ  ---------- */
     // DELETE /api/projects/{projectId}/tasks/{taskId}
     @DeleteMapping("/{taskId}")
+    @Operation(summary = "Delete task")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void delete(@PathVariable Long projectId,
                        @PathVariable Long taskId,
@@ -58,6 +63,7 @@ public class TaskRestController {
     /* ----------  ADD PARTICIPANT (добавить участника)  ---------- */
     // POST /api/projects/{projectId}/tasks/{taskId}/participants/{userId}
     @PostMapping("/{taskId}/participants/{userId}")
+    @Operation(summary = "Add participant to task")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void addParticipant(@PathVariable Long projectId,
                                @PathVariable Long taskId,
@@ -91,6 +97,7 @@ public class TaskRestController {
     /* ----------  REMOVE PARTICIPANT (удалить участника)  ---------- */
     // DELETE /api/projects/{projectId}/tasks/{taskId}/participants/{userId}
     @DeleteMapping("/{taskId}/participants/{userId}")
+    @Operation(summary = "Remove participant from task")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void removeParticipant(@PathVariable Long projectId,
                                   @PathVariable Long taskId,

--- a/demo/src/main/java/itis/semestrovka/demo/controller/TeamRestController.java
+++ b/demo/src/main/java/itis/semestrovka/demo/controller/TeamRestController.java
@@ -3,6 +3,8 @@ package itis.semestrovka.demo.controller;
 import itis.semestrovka.demo.service.TeamService;
 import itis.semestrovka.demo.model.dto.TeamDto;
 import itis.semestrovka.demo.mapper.TeamConverter;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -13,12 +15,14 @@ import org.springframework.web.bind.annotation.*;
 @RequiredArgsConstructor
 @PreAuthorize("hasRole('ROLE_ADMIN')")
 @io.swagger.v3.oas.annotations.security.SecurityRequirement(name = "X-CSRF-TOKEN")
+@Tag(name = "Teams", description = "Operations with teams")
 public class TeamRestController {
 
     private final TeamService teamService;
 
     /** Получить список всех команд. */
     @GetMapping
+    @Operation(summary = "Get all teams")
     public java.util.List<TeamDto> getAll() {
         return teamService.findAllTeams().stream()
                 .map(TeamConverter::toDto)
@@ -28,12 +32,14 @@ public class TeamRestController {
     /** Создать новую команду. */
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
+    @Operation(summary = "Create team")
     public TeamDto create(@RequestBody TeamDto dto) {
         return TeamConverter.toDto(teamService.create(TeamConverter.toEntity(dto)));
     }
 
     /** Получить конкретную команду по id. */
     @GetMapping("/{id}")
+    @Operation(summary = "Get team by id")
     public TeamDto getById(@PathVariable Long id) {
         return TeamConverter.toDto(teamService.findById(id));
     }
@@ -41,6 +47,7 @@ public class TeamRestController {
     /** Удаление пользователя из команды через AJAX */
     @DeleteMapping("/{teamId}/users/{userId}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
+    @Operation(summary = "Remove user from team")
     public void removeUser(
             @PathVariable Long teamId,
             @PathVariable Long userId

--- a/demo/src/test/java/itis/semestrovka/demo/controller/TeamRestControllerTest.java
+++ b/demo/src/test/java/itis/semestrovka/demo/controller/TeamRestControllerTest.java
@@ -1,0 +1,81 @@
+package itis.semestrovka.demo.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import itis.semestrovka.demo.model.dto.TeamDto;
+import itis.semestrovka.demo.model.entity.Team;
+import itis.semestrovka.demo.service.TeamService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(TeamRestController.class)
+class TeamRestControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private TeamService teamService;
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void getAllReturnsTeamList() throws Exception {
+        Team team = new Team();
+        team.setId(1L);
+        team.setName("Alpha");
+        when(teamService.findAllTeams()).thenReturn(List.of(team));
+
+        mockMvc.perform(get("/api/teams"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].id").value(1));
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void createReturnsCreatedTeam() throws Exception {
+        TeamDto dto = new TeamDto();
+        dto.setName("Alpha");
+        Team saved = new Team();
+        saved.setId(2L);
+        when(teamService.create(any(Team.class))).thenReturn(saved);
+
+        mockMvc.perform(post("/api/teams")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(dto)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.id").value(2));
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void getByIdReturnsTeam() throws Exception {
+        Team team = new Team();
+        team.setId(5L);
+        when(teamService.findById(5L)).thenReturn(team);
+
+        mockMvc.perform(get("/api/teams/5"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(5));
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void removeUserCallsService() throws Exception {
+        mockMvc.perform(delete("/api/teams/1/users/7"))
+                .andExpect(status().isNoContent());
+
+        verify(teamService).removeUserFromTeam(1L, 7L);
+    }
+}


### PR DESCRIPTION
## Summary
- document REST endpoints with Swagger annotations
- add example HTTP request files for team and task controllers
- implement `TeamRestControllerTest`
- mention Swagger UI and HTTP files in README

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68435d2cda7c832aa1e4ba47c0ab4245