### PR TITLE
Configure Google OAuth credentials via env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ This project is a simple Spring Boot app used for managing teams and projects. I
    - `GOOGLE_REDIRECT_URI` (optional) – Defaults to `http://localhost:8080/oauth2/callback/google` and must match the allowed redirect URI in Google settings.
    - `SLACK_WEBHOOK_URL` (optional) – Incoming webhook for Slack notifications.
 
+   The `application.yaml` file reads `google.client-id` and `google.client-secret` from these variables, so the application will fail to start if they are not defined.
+
 
 3. Build and run using Maven:
 

--- a/demo/src/main/resources/application.yaml
+++ b/demo/src/main/resources/application.yaml
@@ -21,8 +21,8 @@ spring:
         format_sql: true
 
 google:
-  client-id: 73668923655-n0mnr5d63lph07s2leum9gdn4bug7i5a.apps.googleusercontent.com
-  client-secret: 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
+  client-id: ${GOOGLE_CLIENT_ID}
+  client-secret: ${GOOGLE_CLIENT_SECRET}
   redirect-uri: http://localhost:8080/oauth2/callback/google
 
 slack:


### PR DESCRIPTION
## Summary
- load Google OAuth client ID and secret from environment variables
- document the required variables in the README

## Testing
- `./mvnw test -q` *(fails: Non-resolvable parent POM because the repository is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_684362cff72c832a89b6758cedb98004