### PR TITLE
Add team member API

### DIFF
--- a/demo/src/main/java/itis/semestrovka/demo/controller/TeamRestController.java
+++ b/demo/src/main/java/itis/semestrovka/demo/controller/TeamRestController.java
@@ -1,7 +1,9 @@
 package itis.semestrovka.demo.controller;
 import itis.semestrovka.demo.service.TeamService;
 import itis.semestrovka.demo.model.dto.TeamDto;
+import itis.semestrovka.demo.model.dto.UserDto;
 import itis.semestrovka.demo.mapper.TeamConverter;
+import itis.semestrovka.demo.mapper.UserConverter;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
@@ -11,7 +13,6 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequestMapping("/api/teams")
 @RequiredArgsConstructor
-@PreAuthorize("hasRole('ROLE_ADMIN')")
 @io.swagger.v3.oas.annotations.security.SecurityRequirement(name = "X-CSRF-TOKEN")
 @Tag(name = "Teams", description = "Operations with teams")
 public class TeamRestController {
@@ -25,6 +26,7 @@ public class TeamRestController {
     }
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
     @Operation(summary = "Create team")
     public TeamDto create(@RequestBody TeamDto dto) {
         return TeamConverter.toDto(teamService.create(TeamConverter.toEntity(dto)));
@@ -34,8 +36,17 @@ public class TeamRestController {
     public TeamDto getById(@PathVariable Long id) {
         return TeamConverter.toDto(teamService.findById(id));
     }
+
+    @GetMapping("/{teamId}/users")
+    @Operation(summary = "Get team members")
+    public java.util.List<UserDto> getTeamMembers(@PathVariable Long teamId) {
+        return teamService.findTeamMembers(teamId).stream()
+                .map(UserConverter::toDto)
+                .toList();
+    }
     @DeleteMapping("/{teamId}/users/{userId}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
     @Operation(summary = "Remove user from team")
     public void removeUser(
             @PathVariable Long teamId,

--- a/demo/src/main/java/itis/semestrovka/demo/mapper/UserConverter.java
+++ b/demo/src/main/java/itis/semestrovka/demo/mapper/UserConverter.java
@@ -1,0 +1,42 @@
+package itis.semestrovka.demo.mapper;
+
+import itis.semestrovka.demo.model.dto.UserDto;
+import itis.semestrovka.demo.model.entity.Role;
+import itis.semestrovka.demo.model.entity.Team;
+import itis.semestrovka.demo.model.entity.User;
+
+public class UserConverter {
+    public static UserDto toDto(User user) {
+        if (user == null) return null;
+        UserDto dto = new UserDto();
+        dto.setId(user.getId());
+        dto.setUsername(user.getUsername());
+        dto.setEmail(user.getEmail());
+        dto.setPhone(user.getPhone());
+        if (user.getRole() != null) {
+            dto.setRole(user.getRole().name());
+        }
+        if (user.getTeam() != null) {
+            dto.setTeamId(user.getTeam().getId());
+        }
+        return dto;
+    }
+
+    public static User toEntity(UserDto dto) {
+        if (dto == null) return null;
+        User user = new User();
+        user.setId(dto.getId());
+        user.setUsername(dto.getUsername());
+        user.setEmail(dto.getEmail());
+        user.setPhone(dto.getPhone());
+        if (dto.getRole() != null) {
+            user.setRole(Role.valueOf(dto.getRole()));
+        }
+        if (dto.getTeamId() != null) {
+            Team team = new Team();
+            team.setId(dto.getTeamId());
+            user.setTeam(team);
+        }
+        return user;
+    }
+}

--- a/demo/src/main/java/itis/semestrovka/demo/repository/UserRepository.java
+++ b/demo/src/main/java/itis/semestrovka/demo/repository/UserRepository.java
@@ -15,5 +15,7 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     Optional<User> findByPhone(String phone);
 
+    java.util.List<User> findAllByTeamId(Long teamId);
+
     
 }

--- a/demo/src/main/java/itis/semestrovka/demo/service/TeamService.java
+++ b/demo/src/main/java/itis/semestrovka/demo/service/TeamService.java
@@ -9,6 +9,7 @@ public interface TeamService {
     void deleteById(Long id);
     java.util.List<Team> findByPartialName(String name);
     List<User> findAllUsers();
+    List<User> findTeamMembers(Long teamId);
     void addUserToTeam(Long teamId, Long userId);
     void removeUserFromTeam(Long teamId, Long userId);
 }

--- a/demo/src/main/java/itis/semestrovka/demo/service/impl/TeamServiceImpl.java
+++ b/demo/src/main/java/itis/semestrovka/demo/service/impl/TeamServiceImpl.java
@@ -29,6 +29,11 @@ public class TeamServiceImpl implements TeamService {
     public List<User> findAllUsers() {
         return userRepo.findAll();
     }
+
+    @Override
+    public List<User> findTeamMembers(Long teamId) {
+        return userRepo.findAllByTeamId(teamId);
+    }
     @Override
     public void addUserToTeam(Long teamId, Long userId) {
         Team team = teamRepo.findById(teamId).orElseThrow();
@@ -38,13 +43,11 @@ public class TeamServiceImpl implements TeamService {
     }
     @Override
     public void removeUserFromTeam(Long teamId, Long userId) {
-        Team team = teamRepo.findById(teamId).orElseThrow();
         User user = userRepo.findById(userId).orElseThrow();
-            Team userTeam = user.getTeam();
-        if (userTeam == null || !userTeam.getId().equals(team.getId())) {
+        Team userTeam = user.getTeam();
+        if (userTeam == null || !userTeam.getId().equals(teamId)) {
             throw new IllegalStateException("Пользователь не состоит в этой команде");
         }
-
         user.setTeam(null);
         userRepo.save(user);
     }

--- a/demo/src/main/resources/templates/team/view.html
+++ b/demo/src/main/resources/templates/team/view.html
@@ -44,7 +44,7 @@
           </div>
           <div class="row mb-2">
             <div class="col-sm-3 text-muted">Участников:</div>
-            <div class="col-sm-9" th:text="${team.members.size()} + ' чел.'">0 чел.</div>
+            <div class="col-sm-9" id="memberTotal">0 чел.</div>
           </div>
         </div>
         <div class="card-footer">
@@ -75,26 +75,16 @@
                 <th sec:authorize="hasRole('ROLE_ADMIN')" class="text-end">Действия</th>
               </tr>
               </thead>
-              <tbody>
-              <tr th:each="user : ${team.members}">
-                <td th:text="${user.username}">user</td>
-                <td sec:authorize="hasRole('ROLE_ADMIN')" class="text-end">
-                  <button type="button"
-                          class="btn btn-sm btn-outline-danger btn-remove-user"
-                          th:data-user-id="${user.id}">
-                    Удалить
-                  </button>
-                </td>
-              </tr>
-              <tr th:if="${#lists.isEmpty(team.members)}">
-                <td class="text-center py-3" colspan="2">Участников нет</td>
+              <tbody id="membersBody">
+              <tr>
+                <td class="text-center py-3" colspan="2">Загрузка...</td>
               </tr>
               </tbody>
             </table>
           </div>
         </div>
         <div class="card-footer text-muted">
-          Всего участников: <span id="memberCount" th:text="${team.members.size()}">0</span>
+          Всего участников: <span id="memberCount">0</span>
         </div>
       </div>
     </div>
@@ -105,32 +95,56 @@
     const teamId = /*[[${team.id}]]*/ 0;
     const csrfHeader = /*[['${_csrf.headerName}']]*/ 'X-CSRF-TOKEN';
     const csrfToken  = /*[['${_csrf.token}']]*/ '';
+    const isAdmin    = /*[[${#authorization.expression('hasRole(''ADMIN'')')}]]*/ false;
 
-    document.querySelectorAll('.btn-remove-user').forEach(btn => {
-      btn.addEventListener('click', async () => {
-        if (!confirm('Удалить пользователя из команды?')) return;
-        const userId = btn.dataset.userId;
-        const resp = await fetch(`/api/teams/${teamId}/users/${userId}`, {
-          method: 'DELETE',
-          headers: { [csrfHeader]: csrfToken }
-        });
-        if (resp.ok) {
-          const row = btn.closest('tr');
-          row.remove();
-          const tbody = document.querySelector('#membersTable tbody');
-          const countElem = document.getElementById('memberCount');
-          const rows = tbody.querySelectorAll('tr');
-          countElem.textContent = rows.length;
-          if (rows.length === 0) {
-            const tr = document.createElement('tr');
-            tr.innerHTML = '<td class="text-center py-3" colspan="2">Участников нет</td>';
-            tbody.appendChild(tr);
+    async function loadMembers() {
+      const resp = await fetch(`/api/teams/${teamId}/users`);
+      const members = await resp.json();
+
+      const tbody = document.getElementById('membersBody');
+      tbody.innerHTML = '';
+      if (members.length === 0) {
+        const tr = document.createElement('tr');
+        tr.innerHTML = '<td class="text-center py-3" colspan="2">Участников нет</td>';
+        tbody.appendChild(tr);
+      } else {
+        members.forEach(m => {
+          const tr = document.createElement('tr');
+          const tdName = document.createElement('td');
+          tdName.textContent = m.username;
+          tr.appendChild(tdName);
+          if (isAdmin) {
+            const tdAct = document.createElement('td');
+            tdAct.className = 'text-end';
+            const btn = document.createElement('button');
+            btn.type = 'button';
+            btn.className = 'btn btn-sm btn-outline-danger';
+            btn.textContent = 'Удалить';
+            btn.addEventListener('click', () => removeUser(m.id));
+            tdAct.appendChild(btn);
+            tr.appendChild(tdAct);
           }
-        } else {
-          alert('Ошибка удаления участника');
-        }
+          tbody.appendChild(tr);
+        });
+      }
+      document.getElementById('memberCount').textContent = members.length;
+      document.getElementById('memberTotal').textContent = members.length + ' чел.';
+    }
+
+    async function removeUser(userId) {
+      if (!confirm('Удалить пользователя из команды?')) return;
+      const resp = await fetch(`/api/teams/${teamId}/users/${userId}`, {
+        method: 'DELETE',
+        headers: { [csrfHeader]: csrfToken }
       });
-    });
+      if (resp.ok) {
+        await loadMembers();
+      } else {
+        alert('Ошибка удаления участника');
+      }
+    }
+
+    document.addEventListener('DOMContentLoaded', loadMembers);
     /*]]>*/
   </script>
 </div>

--- a/demo/src/test/java/itis/semestrovka/demo/controller/TeamRestControllerTest.java
+++ b/demo/src/test/java/itis/semestrovka/demo/controller/TeamRestControllerTest.java
@@ -3,6 +3,7 @@ package itis.semestrovka.demo.controller;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import itis.semestrovka.demo.model.dto.TeamDto;
 import itis.semestrovka.demo.model.entity.Team;
+import itis.semestrovka.demo.model.entity.User;
 import itis.semestrovka.demo.service.TeamService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -77,5 +78,18 @@ class TeamRestControllerTest {
                 .andExpect(status().isNoContent());
 
         verify(teamService).removeUserFromTeam(1L, 7L);
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void getMembersReturnsUserList() throws Exception {
+        User u = new User();
+        u.setId(3L);
+        u.setUsername("user");
+        when(teamService.findTeamMembers(1L)).thenReturn(List.of(u));
+
+        mockMvc.perform(get("/api/teams/1/users"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].id").value(3));
     }
 }


### PR DESCRIPTION
## Summary
- list team members via REST and delete them safely
- expose API endpoints for team members
- fetch members dynamically on team page
- provide UserConverter for DTO mapping
- test new REST endpoint
- make team-member listing accessible to all while restricting modifications to admins

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68437f636764832aa77728b10218e46e