### PR TITLE
Fix team member deletion via frontend

### DIFF
--- a/demo/src/main/resources/templates/task/details.html
+++ b/demo/src/main/resources/templates/task/details.html
@@ -131,7 +131,8 @@
       const userId = btn.dataset.userId;
       const resp = await fetch(`/projects/${projectId}/tasks/${taskId}/participants/${userId}/delete`, {
         method: 'POST',
-        headers: { [csrfHeader]: csrfToken }
+        headers: { [csrfHeader]: csrfToken },
+        credentials: 'same-origin'
       });
       if (resp.ok) {
         const item = btn.closest('.participant-item');

--- a/demo/src/main/resources/templates/task/form.html
+++ b/demo/src/main/resources/templates/task/form.html
@@ -104,7 +104,8 @@
       const userId = btn.dataset.userId;
       const resp = await fetch(`/projects/${projectId}/tasks/${taskId}/participants/${userId}/delete`, {
         method: 'POST',
-        headers: { [csrfHeader]: csrfToken }
+        headers: { [csrfHeader]: csrfToken },
+        credentials: 'same-origin'
       });
       if (resp.ok) {
         const li = btn.closest('.participant-item');

--- a/demo/src/main/resources/templates/team/view.html
+++ b/demo/src/main/resources/templates/team/view.html
@@ -99,7 +99,9 @@
     // Функция загрузки списка участников
     async function loadMembers() {
       console.log('Loading members for team', teamId);
-      const resp = await fetch(`/api/teams/${teamId}/users`);
+      const resp = await fetch(`/api/teams/${teamId}/users`, {
+        credentials: 'same-origin'
+      });
       console.log('GET /api/teams/' + teamId + '/users ->', resp.status);
       const members = await resp.json();
 
@@ -138,7 +140,8 @@
       console.log('DELETE request to:', url);
       const resp = await fetch(url, {
         method: 'DELETE',
-        headers: { [csrfHeader]: csrfToken }
+        headers: { [csrfHeader]: csrfToken },
+        credentials: 'same-origin'
       });
       console.log('Response:', resp.status, await resp.text());
       if (resp.ok) {


### PR DESCRIPTION
## Summary
- send credentials with fetch requests so session cookies are included
- apply the same tweak to task pages

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68438643d500832a9f0a1adc066575ab